### PR TITLE
Zenodo API Get Method

### DIFF
--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -1,6 +1,7 @@
 name: Django CI
 
 on:
+  workflow_dispatch:
   push:
     branches: [ "main" ]
   pull_request:

--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -9,7 +9,7 @@ on:
 env:
   serp_api_key: ${{ secrets.SERP_API_KEY }}
   SECRET_KEY: ${{ secrets.SECRET_KEY }}
-
+  ZENODO_API_KEY: ${{ secrets.ZENODO_API_KEY }}
 
 jobs:
   build:

--- a/practice_app/api/api_keys.py
+++ b/practice_app/api/api_keys.py
@@ -2,5 +2,6 @@ import os
 
 
 api_keys = {
-    'serp_api' : os.getenv('serp_api_key')
+    'serp_api' : os.getenv('serp_api_key'),
+    'zenodo_api': os.getenv('ZENODO_API_KEY')
 }

--- a/practice_app/api/tests.py
+++ b/practice_app/api/tests.py
@@ -102,3 +102,36 @@ class EricPapersTestCase(TestCase):
         self.assertContains(response, 'date')
         self.assertContains(response, 'url')
         self.assertContains(response, 'position')
+class zenodo_test_cases(TestCase):
+
+    def setUp(self):
+        self.c = Client()
+
+    def tearDown(self):
+        print('GET Tests Completed Successfully')
+
+    def test_zenodo_api(self):
+        ACCESS_TOKEN = api_keys.api_keys['ZENODO_API_KEY']
+        request = requests.get('https://zenodo.org/api/records',
+                               params={'q': 'test', 'sort': 'bestmatch', 'size': 3,
+                                       'access_token': ACCESS_TOKEN})
+        self.assertEquals(request.status_code, 200, "Zenodo API didn't work as supposed to")
+        response = self.c.get("/zenodo?search_title=test&rows=3")
+        self.assertEquals(response.status_code, 200)
+        response_content = response.json()['results']
+        self.assertEquals(len(response_content), 3)
+        count = 0
+        for result in response_content:
+            self.assertIn('source', result.keys())
+            self.assertEquals(result['source'], 'zenodo')
+            self.assertIn('authors', result.keys())
+            self.assertIn('id', result.keys())
+            self.assertIn('abstract', result.keys())
+            self.assertIn('url', result.keys())
+            self.assertIn('position', result.keys())
+            self.assertIn('date', result.keys())
+            self.assertIn('title', result.keys())
+            self.assertEquals(response[count]['title'], result['title'])
+            self.assertEquals(response[count]['link'], result['url'])
+            self.assertEquals(response[count]['position'], result['pos'])
+            count += 1

--- a/practice_app/api/tests.py
+++ b/practice_app/api/tests.py
@@ -116,7 +116,7 @@ class ZenodoTestCases(TestCase):
                                params={'q': 'test', 'sort': 'bestmatch', 'size': 3,
                                        'access_token': ACCESS_TOKEN})
         self.assertEquals(request.status_code, 200, "Zenodo API didn't work as supposed to")
-        response = self.c.get("/zenodo/?title=test&rows=3")
+        response = self.c.get("/api/zenodo/?title=test&rows=3")
         self.assertEquals(response.status_code, 200)
         response_content = response.json()['results']
         self.assertEquals(len(response_content), 3)

--- a/practice_app/api/tests.py
+++ b/practice_app/api/tests.py
@@ -116,7 +116,7 @@ class zenodo_test_cases(TestCase):
                                params={'q': 'test', 'sort': 'bestmatch', 'size': 3,
                                        'access_token': ACCESS_TOKEN})
         self.assertEquals(request.status_code, 200, "Zenodo API didn't work as supposed to")
-        response = self.c.get("/zenodo?search_title=test&rows=3")
+        response = self.c.get("/zenodo/?title=test&rows=3")
         self.assertEquals(response.status_code, 200)
         response_content = response.json()['results']
         self.assertEquals(len(response_content), 3)

--- a/practice_app/api/tests.py
+++ b/practice_app/api/tests.py
@@ -102,7 +102,7 @@ class EricPapersTestCase(TestCase):
         self.assertContains(response, 'date')
         self.assertContains(response, 'url')
         self.assertContains(response, 'position')
-class zenodo_test_cases(TestCase):
+class ZenodoTestCases(TestCase):
 
     def setUp(self):
         self.c = Client()

--- a/practice_app/api/tests.py
+++ b/practice_app/api/tests.py
@@ -111,7 +111,7 @@ class zenodo_test_cases(TestCase):
         print('GET Tests Completed Successfully')
 
     def test_zenodo_api(self):
-        ACCESS_TOKEN = api_keys.api_keys['ZENODO_API_KEY']
+        ACCESS_TOKEN = api_keys.api_keys['zenodo_api']
         request = requests.get('https://zenodo.org/api/records',
                                params={'q': 'test', 'sort': 'bestmatch', 'size': 3,
                                        'access_token': ACCESS_TOKEN})

--- a/practice_app/api/tests.py
+++ b/practice_app/api/tests.py
@@ -111,11 +111,6 @@ class ZenodoTestCases(TestCase):
         print('GET Tests Completed Successfully')
 
     def test_zenodo_api(self):
-        ACCESS_TOKEN = api_keys.api_keys['zenodo_api']
-        request = requests.get('https://zenodo.org/api/records',
-                               params={'q': 'test', 'sort': 'bestmatch', 'size': 3,
-                                       'access_token': ACCESS_TOKEN})
-        self.assertEquals(request.status_code, 200, "Zenodo API didn't work as supposed to")
         response = self.c.get("/api/zenodo/?title=test&rows=3")
         self.assertEquals(response.status_code, 200)
         response_content = response.json()['results']

--- a/practice_app/api/tests.py
+++ b/practice_app/api/tests.py
@@ -118,7 +118,7 @@ class ZenodoTestCases(TestCase):
         count = 0
         for result in response_content:
             self.assertIn('source', result.keys())
-            self.assertEquals(result['source'], 'zenodo')
+            self.assertEquals(result['source'], 'Zenodo')
             self.assertIn('authors', result.keys())
             self.assertIn('id', result.keys())
             self.assertIn('abstract', result.keys())
@@ -126,7 +126,7 @@ class ZenodoTestCases(TestCase):
             self.assertIn('position', result.keys())
             self.assertIn('date', result.keys())
             self.assertIn('title', result.keys())
-            self.assertEquals(response[count]['title'], result['title'])
-            self.assertEquals(response[count]['link'], result['url'])
-            self.assertEquals(response[count]['position'], result['pos'])
+            self.assertEquals(response_content[count]['title'], result['title'])
+            self.assertEquals(response_content[count]['url'], result['url'])
+            self.assertEquals(response_content[count]['position'], result['position'])
             count += 1

--- a/practice_app/api/urls.py
+++ b/practice_app/api/urls.py
@@ -4,5 +4,6 @@ from . import views
 app_name = "api"
 urlpatterns = [
     path("google-scholar/", views.google_scholar, name="google-scholar"),
-    path('eric/', views.eric_papers, name='eric_papers')
+    path('eric/', views.eric_papers, name='eric_papers'),
+    path("zenodo/",views.zenodo, name="zenodo")
     ]

--- a/practice_app/api/views.py
+++ b/practice_app/api/views.py
@@ -109,7 +109,7 @@ def eric_papers(request):
         return JsonResponse({'message':'Internal server error'}, status=503)
 def zenodo(request):
     ACCESS_TOKEN = api_keys.api_keys['zenodo_api']
-    search_title = request.GET.get("search_title", None)
+    search_title = request.GET.get("title", None)
     rows = request.GET.get('rows', 5)
     if search_title is None or search_title == "" or search_title.isspace() is True:
         return JsonResponse({'status': 'Title to search must be given.'}, status=404)

--- a/practice_app/api/views.py
+++ b/practice_app/api/views.py
@@ -108,7 +108,7 @@ def eric_papers(request):
     else:
         return JsonResponse({'message':'Internal server error'}, status=503)
 def zenodo(request):
-    ACCESS_TOKEN = api_keys.api_keys['ZENODO_API_KEY']
+    ACCESS_TOKEN = api_keys.api_keys['zenodo_api']
     search_title = request.GET.get("search_title", None)
     rows = request.GET.get('rows', 5)
     if search_title is None or search_title == "" or search_title.isspace() is True:

--- a/practice_app/api/views.py
+++ b/practice_app/api/views.py
@@ -107,3 +107,38 @@ def eric_papers(request):
         return JsonResponse({'message':'Resource not found'}, status=404)
     else:
         return JsonResponse({'message':'Internal server error'}, status=503)
+def zenodo(request):
+    ACCESS_TOKEN = api_keys.api_keys['ZENODO_API_KEY']
+    search_title = request.GET.get("search_title", None)
+    rows = request.GET.get('rows', 5)
+    if search_title is None or search_title == "" or search_title.isspace() is True:
+        return JsonResponse({'status': 'Title to search must be given.'}, status=404)
+
+    request = requests.get('https://zenodo.org/api/records',
+                     params={'q': search_title, 'sort': 'bestmatch', 'size': rows, 'access_token': ACCESS_TOKEN})
+
+    if request.status_code == 200:
+        papers = request.json()["hits"]["hits"]
+        response = {}
+        results = []
+        for paper in papers:
+            paper_info = {}
+            paper_info['id'] = paper['id']
+            paper_info['title'] = paper['metadata']['title']
+            paper_info['url'] = paper['links']['doi']
+            paper_info['authors'] = []
+            paper_info['abstract'] = paper['metadata']['description']
+            paper_info['date'] = int(paper['metadata']['publication_date'].split("-")[0])
+            paper_info['position'] = papers.index(paper)
+            paper_info['source'] = 'Zenodo'
+            authors = paper['metadata']['creators']
+            for author in authors:
+                paper_info['authors'].append(author['name'])
+            results.append(paper_info.copy())
+        response['results'] = results
+        return JsonResponse(response, status=200)
+    elif request.status_code == 404:
+        return JsonResponse({'status': 'Unsuccessful Search.'}, status=404)
+    else:
+        return JsonResponse({'status': 'An internal server error has occured. Please try again.'}, status=503)
+

--- a/practice_app/practice_app/settings.py
+++ b/practice_app/practice_app/settings.py
@@ -20,7 +20,7 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 # See https://docs.djangoproject.com/en/4.2/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = os.getenv('SECRET_KEY')
+SECRET_KEY = os.environ.get('SECRET_KEY')
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True


### PR DESCRIPTION
This pull request implements a new GET method that utilizes Zenodo API. The new method allows users to retrieve papers by its identifier, including the record's metadata.

Fixes #116.