### PR TITLE
POST Method to Send Follow Request

### DIFF
--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -39,8 +39,8 @@ jobs:
         pip install -r requirements.txt
     - name: Run migrations
       run: |
+        python manage.py makemigrations
         python manage.py migrate
-        python manage.py makemigrate
     - name: Run Tests
       run: |
         python manage.py test

--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -37,6 +37,10 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -r requirements.txt
+    - name: Run migrations
+      run: |
+        python manage.py migrate
+        python manage.py makemigrate
     - name: Run Tests
       run: |
         python manage.py test

--- a/practice_app/api/tests.py
+++ b/practice_app/api/tests.py
@@ -3,7 +3,6 @@ from unittest import skip
 import requests
 import json
 from . import api_keys
-from . import models
 from django.contrib.auth.models import User
 # Create your tests here.
 

--- a/practice_app/api/tests.py
+++ b/practice_app/api/tests.py
@@ -431,12 +431,12 @@ class FollowUserTestCase(TestCase):
         # no followed username is provided
         response = self.c.post("/api/follow_user/", headers = Headers)
         
-        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.status_code, 400)
         self.assertEqual(response.json()['status'], "Username of followed should be provided.")
 
         # empty followed username is provided
         response = self.c.post("/api/follow_user/", headers = Headers, data = {'followed_username':''})
-        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.status_code, 400)
         self.assertEqual(response.json()['status'], "Username of followed should be provided.")
 
         # followed is not a valid username

--- a/practice_app/api/tests.py
+++ b/practice_app/api/tests.py
@@ -443,7 +443,6 @@ class FollowUserTestCase(TestCase):
         Headers = {'username': "0009-0005-5924-1831", "password": "strongpassword"}
         Body = {'followed_username':'0009-0005-5924-1832'}
         response = self.c.post("/api/follow_user/", headers = Headers, data = Body)
-        print(response.json())
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json()['status'], "User followed.")
 

--- a/practice_app/api/urls.py
+++ b/practice_app/api/urls.py
@@ -13,4 +13,5 @@ urlpatterns = [
     path("log_in/", views.log_in, name="log_in"),
     path("log_out/", views.log_out, name="log_out"),
     path("user_registration/", views.user_registration, name="user_registration"),
+    path("follow_user/", views.follow_user, name="follow_user"),
 ]

--- a/practice_app/api/views.py
+++ b/practice_app/api/views.py
@@ -441,7 +441,7 @@ def follow_user(request):
     query = request.POST
     followed_username = query.get('followed_username')
     if followed_username == None or followed_username == '':
-        return JsonResponse({"status":"Username of followed should be provided."}, status = 404)
+        return JsonResponse({"status":"Username of followed should be provided."}, status = 400)
     
     if User.objects.filter(username=followed_username).exists():
         followed_user = User.objects.get(username=followed_username)


### PR DESCRIPTION
### **Related Issue:** #150 

### **How?**
POST API endpoint can be accessed via the "_follow_user/_" route and makes modifications to the Django database models. If the user is not signed in, the '_username_' and '_password_' of the follower user must be provided in the headers for authentication purposes. If the user is already signed in, the API will automatically follow the user, and the headers will be ignored. The '_followed_username_' must be provided in the data to specify the user that the follower wants to follow.

### **Testing?**

- The functionality has been thoroughly tested using _**unit tests**_.
- Additionally, the implementation has been tested via Postman after deployment on a local environment. A valid request example is available **_in our Postman workspace_**. Please note that you need to create the users that will be used in the request before calling this API.