### PR TITLE
GET Method for NASA STI OpenAPI 

### DIFF
--- a/practice_app/api/tests.py
+++ b/practice_app/api/tests.py
@@ -318,6 +318,76 @@ class SemanticScholarTestCase(TestCase):
             # self.assertEquals(semantic_scholar_api_response[count]['url'], result['url']) # This API usually returns different results for same query
             self.assertEquals(count, result['position'])
 
+class NasaStiTestCase(TestCase):
+    def setUp(self):
+        self.client = Client()
+
+    def tearDown(self):
+        print('GET Tests of Nasa STI Completed Successfully')
+
+    def test_4xx_responses(self):
+        self.assertEquals(self.client.get("/api/nasa-sti/?title=").status_code, 400)
+        self.assertEquals(self.client.get("/api/nasa-sti/?").status_code, 400)
+        self.assertEquals(self.client.get("/api/nasa-sti/").status_code, 400)
+        self.assertEquals(self.client.get("/api/nasa-sti/?rows=9").status_code, 400)
+        self.assertEquals(self.client.get("/api/nasa-sti/title=space").status_code, 404)
+        self.assertEquals(self.client.get("/api/nasa-sti/?title=&").status_code, 400)
+
+    def test_valid_title_valid_rows(self):
+        # test when valid title and rows are provided
+
+        field_count = 8
+        rows = 10
+
+        response = self.client.get('/api/nasa-sti/?title=space&rows='+str(rows))
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.json()['results'][0]), field_count)
+        self.assertEqual(len(response.json()['results']), rows)
+        self.assertContains(response, 'id')
+        self.assertContains(response, 'title')
+        self.assertContains(response, 'authors')
+        self.assertContains(response, 'abstract')
+        self.assertContains(response, 'source')
+        self.assertContains(response, 'date')
+        self.assertContains(response, 'url')
+        self.assertContains(response, 'position')
+    
+    def test_valid_title_no_rows(self):
+        # test when valid title and no rows are provided
+
+        field_count = 8
+
+        response = self.client.get('/api/nasa-sti/?title=space')
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.json()['results'][0]), field_count)
+        self.assertEqual(len(response.json()['results']), 3)
+        self.assertContains(response, 'id')
+        self.assertContains(response, 'title')
+        self.assertContains(response, 'author')
+        self.assertContains(response, 'abstract')
+        self.assertContains(response, 'source')
+        self.assertContains(response, 'date')
+        self.assertContains(response, 'url')
+        self.assertContains(response, 'position')
+
+    def test_valid_title_non_numeric_rows(self):
+        # test when valid title and non-numeric rows are provided
+
+        field_count = 8
+
+        response = self.client.get('/api/nasa-sti/?title=space')
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.json()['results'][0]), field_count)
+        self.assertEqual(len(response.json()['results']), 3)
+        self.assertContains(response, 'id')
+        self.assertContains(response, 'title')
+        self.assertContains(response, 'author')
+        self.assertContains(response, 'abstract')
+        self.assertContains(response, 'source')
+        self.assertContains(response, 'date')
+        self.assertContains(response, 'url')
+        self.assertContains(response, 'position')
+
 class orcid_api_test_cases(TestCase):
 
     def setUp(self):

--- a/practice_app/api/tests.py
+++ b/practice_app/api/tests.py
@@ -375,7 +375,7 @@ class NasaStiTestCase(TestCase):
 
         field_count = 8
 
-        response = self.client.get('/api/nasa-sti/?title=space')
+        response = self.client.get('/api/nasa-sti/?title=space&rows=abc')
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.json()['results'][0]), field_count)
         self.assertEqual(len(response.json()['results']), 3)

--- a/practice_app/api/urls.py
+++ b/practice_app/api/urls.py
@@ -11,6 +11,7 @@ urlpatterns = [
     path('eric/', views.eric_papers, name='eric_papers'),
     path("zenodo/",views.zenodo, name="zenodo"),
     path('semantic-scholar/', views.semantic_scholar, name='semantic-scholar'),
+    path("nasa-sti/",views.nasa_sti, name="nasa-sti"),
     path("orcid-api/", views.orcid_api, name="orcid_api"),
     path("log-in/", views.log_in, name="log_in"),
     path("log-out/", views.log_out, name="log_out"),


### PR DESCRIPTION
### **Related Issue:** #162 

### **Changes:**

- Corresponding URL is added to _/urls.py_
- Implementation is added to _/views.py_
- Unit tests are added to _/tests.py_

### **How?**
The GET API endpoint can be accessed via the "_nasa-sti/_" route, it makes a call to NASA STI OpenAPI and searches the papers with given parameters in NASA STI  database. It accepts two parameters: "title" (required) and "rows" (optional). The API returns a response in the agreed format in the team discord.

### **Testing?**

- The functionality has been tested using _**unit tests**_.
- Additionally, the implementation has been tested via Postman after deployment on a local environment. A valid request example is available **_in our Postman workspace_**. 
 