### PR TITLE
Node to graph navigate

### DIFF
--- a/project/FrontEnd/collaborative_science_platform/lib/screens/node_details_page/widgets/node_details.dart
+++ b/project/FrontEnd/collaborative_science_platform/lib/screens/node_details_page/widgets/node_details.dart
@@ -1,13 +1,17 @@
 import 'package:collaborative_science_platform/models/node_details_page/node_detailed.dart';
+import 'package:collaborative_science_platform/screens/graph_page/graph_page.dart';
 import 'package:collaborative_science_platform/screens/node_details_page/widgets/contributors_list_view.dart';
 import 'package:collaborative_science_platform/screens/node_details_page/widgets/node_details_tab_bar.dart';
 import 'package:collaborative_science_platform/screens/node_details_page/widgets/proof_list_view.dart';
 import 'package:collaborative_science_platform/screens/node_details_page/widgets/questions_list_view.dart';
 import 'package:collaborative_science_platform/screens/node_details_page/widgets/references_list_view.dart';
+import 'package:collaborative_science_platform/utils/colors.dart';
 import 'package:collaborative_science_platform/utils/text_styles.dart';
+import 'package:collaborative_science_platform/widgets/app_button.dart';
 import 'package:collaborative_science_platform/widgets/card_container.dart';
 import 'package:collaborative_science_platform/utils/responsive/responsive.dart';
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
 
 class NodeDetails extends StatefulWidget {
   final NodeDetailed node;
@@ -60,7 +64,8 @@ class _NodeDetailsState extends State<NodeDetails> {
                           textAlign: TextAlign.center,
                           style: TextStyles.title2)),
                   Row(
-                    mainAxisAlignment: MainAxisAlignment.start,
+                    mainAxisAlignment: MainAxisAlignment.spaceBetween, children: [
+                    Column(
                     children: [
                       RichText(
                         text: TextSpan(children: <TextSpan>[
@@ -76,6 +81,23 @@ class _NodeDetailsState extends State<NodeDetails> {
                       ),
                     ],
                   ),
+                    Column(
+                      children: [
+                        SizedBox(
+                          width: Responsive.getGenericPageWidth(context) * 0.3,
+                          child: AppButton(
+                              text: "See the Graph",
+                              height: 40,
+                              type: "secondary",
+                              onTap: () {
+                                context.push('${GraphPage.routeName}/${widget.node.nodeId}');
+                              }),
+                        )
+                      ],
+                    ),
+                  ]),
+                  
+                  
                 ],
               )),
             ),

--- a/project/FrontEnd/collaborative_science_platform/lib/widgets/app_button.dart
+++ b/project/FrontEnd/collaborative_science_platform/lib/widgets/app_button.dart
@@ -7,6 +7,7 @@ class AppButton extends StatelessWidget {
   final void Function() onTap;
   final bool isActive;
   final bool isLoading;
+  final String type; 
 
   const AppButton({
     super.key,
@@ -15,6 +16,7 @@ class AppButton extends StatelessWidget {
     required this.onTap,
     this.isActive = true,
     this.isLoading = false,
+    this.type = "primary",
   });
 
   @override
@@ -22,7 +24,11 @@ class AppButton extends StatelessWidget {
     return ElevatedButton(
       onPressed: isActive ? onTap : () {},
       style: ElevatedButton.styleFrom(
-        backgroundColor: isActive ? AppColors.primaryColor : Colors.grey[600],
+        backgroundColor: isActive
+            ? (type == "primary"
+                ? AppColors.primaryColor
+                : (type == "secondary" ? AppColors.secondaryColor : Colors.grey[600]))
+            : Colors.grey[600],
         shape: RoundedRectangleBorder(
           borderRadius: BorderRadius.circular(height / 2.0),
         ),


### PR DESCRIPTION
A button is added to link node details page with the related graph page. An optional button type parameter type is added to the AppButton widget. Now, possible button types are only "primary" and "secondary". We can add more button types to enhance the UX of the platform. Closes #406