### PR TITLE
Implement Request POST Methods

### DIFF
--- a/project/backend/api/tests.py
+++ b/project/backend/api/tests.py
@@ -3,10 +3,9 @@ from django.urls import reverse
 from rest_framework import status
 from rest_framework.test import APIClient
 from django.contrib.auth.models import User
-from database.models import BasicUser,Contributor,Node,Question, Proof, Theorem
 from rest_framework.authtoken.models import Token
 from database.serializers import RegisterSerializer, UserSerializer
-from database import models
+from database.models import *
 import datetime
 # Create your tests here for each class or API call.
 
@@ -147,8 +146,8 @@ class SearchAPITestCase(TestCase):
         user = User.objects.create_user(id=1, email='test@example.com', username='test@example.com', first_name='User',
                                         last_name='Test')
         # basic_user = BasicUser.objects.create(user=user, bio='Hello')
-        cont = models.Contributor.objects.create(user=user, bio='Hello',id=1)
-        node = models.Node.objects.create(node_title='test',
+        cont = Contributor.objects.create(user=user, bio='Hello',id=1)
+        node = Node.objects.create(node_title='test',
                                    theorem=None,
                                    publish_date="2023-01-01",
                                    is_valid=True,
@@ -492,3 +491,76 @@ class WorkspaceGETAPITestCase(TestCase):
         # self.assertEqual(response.json()['created_at'], self.workspace.created_at)
 
 
+class CollaborationRequestAPITestCase(TestCase):
+
+    def tearDown(self):
+        Workspace.objects.all().delete()
+        User.objects.all().delete()
+        Contributor.objects.all().delete()
+        CollaborationRequest.objects.all().delete()
+        print("Test for the CollaborationRequest API is completed!")
+        
+    def setUp(self):
+        self.client = APIClient()
+
+        self.workspace = Workspace.objects.create()
+        self.contributor_receiver = Contributor.objects.create(user=User.objects.create(username="receiver"))
+        self.contributor_sender = Contributor.objects.create(user=User.objects.create(username="sender"))
+
+        self.request = CollaborationRequest.objects.create(workspace=self.workspace,receiver=self.contributor_receiver,sender=self.contributor_sender)
+
+        self.request_data = {
+            'sender': self.contributor_sender.id,
+            'receiver': self.contributor_receiver.id,
+            'title' : 'Request Test Title',
+            'body': 'Request Test Body',
+            'workspace': self.workspace.workspace_id
+        }
+
+    def test_send_collab_request(self):
+        url = reverse('send_col_req')
+        response = self.client.post(url, self.request_data, format='json')
+        self.assertEqual(response.status_code, 201)
+    
+    def update_collab_request(self):
+        url = reverse('update_req')
+        response = self.client.put(url, {'id': self.request_data[id], 'status': 'A'}, format='json')
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data.status, 'A')
+
+class ReviewRequestAPITestCase(TestCase):
+
+    def tearDown(self):
+        Workspace.objects.all().delete()
+        User.objects.all().delete()
+        Contributor.objects.all().delete()
+        ReviewRequest.objects.all().delete()
+        print("Test for the ReviewRequest API is completed!")
+        
+    def setUp(self):
+        self.client = APIClient()
+
+        self.workspace = Workspace.objects.create()
+        self.reviewer_receiver = Contributor.objects.create(user=User.objects.create(username="receiver"))
+        self.contributor_sender = Contributor.objects.create(user=User.objects.create(username="sender"))
+
+        self.request = ReviewRequest.objects.create(workspace=self.workspace,receiver=self.reviewer_receiver,sender=self.contributor_sender)
+
+        self.request_data = {
+            'sender': self.contributor_sender.id,
+            'receiver': self.reviewer_receiver.id,
+            'title' : 'Review Request Test Title',
+            'body': 'Review Request Test Body',
+            'workspace': self.workspace.workspace_id
+        }
+
+    def test_send_review_request(self):
+        url = reverse('send_rev_req')
+        response = self.client.post(url, self.request_data, format='json')
+        self.assertEqual(response.status_code, 201)
+    
+    def update_review_request(self):
+        url = reverse('update_req')
+        response = self.client.put(url, {'id': self.request_data[id], 'status': 'R'}, format='json')
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data.status, 'R')

--- a/project/backend/api/tests.py
+++ b/project/backend/api/tests.py
@@ -512,8 +512,6 @@ class CollaborationRequestAPITestCase(TestCase):
         self.request_data = {
             'sender': self.contributor_sender.id,
             'receiver': self.contributor_receiver.id,
-            'title' : 'Request Test Title',
-            'body': 'Request Test Body',
             'workspace': self.workspace.workspace_id
         }
 
@@ -522,11 +520,15 @@ class CollaborationRequestAPITestCase(TestCase):
         response = self.client.post(url, self.request_data, format='json')
         self.assertEqual(response.status_code, 201)
     
-    def update_collab_request(self):
+    def test_update_collab_request(self):
         url = reverse('update_req')
-        response = self.client.put(url, {'id': self.request_data[id], 'status': 'A'}, format='json')
+        response = self.client.put(url, {'id': self.request.id, 'status': 'A'}, format='json')
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.data.status, 'A')
+        self.assertEqual(response.data['status'], 'A')
+
+        receiver = Contributor.objects.get(pk=self.request_data['receiver'])
+        self.assertGreater(receiver.workspaces.filter(pk=self.request_data['workspace']).count(), 0)
+        # self.assert()
 
 class ReviewRequestAPITestCase(TestCase):
 
@@ -549,8 +551,6 @@ class ReviewRequestAPITestCase(TestCase):
         self.request_data = {
             'sender': self.contributor_sender.id,
             'receiver': self.reviewer_receiver.id,
-            'title' : 'Review Request Test Title',
-            'body': 'Review Request Test Body',
             'workspace': self.workspace.workspace_id
         }
 
@@ -559,8 +559,8 @@ class ReviewRequestAPITestCase(TestCase):
         response = self.client.post(url, self.request_data, format='json')
         self.assertEqual(response.status_code, 201)
     
-    def update_review_request(self):
+    def test_update_review_request(self):
         url = reverse('update_req')
-        response = self.client.put(url, {'id': self.request_data[id], 'status': 'R'}, format='json')
+        response = self.client.put(url, {'id': self.request.id, 'status': 'R'}, format='json')
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.data.status, 'R')
+        self.assertEqual(response.data['status'], 'R')

--- a/project/backend/api/urls.py
+++ b/project/backend/api/urls.py
@@ -17,4 +17,7 @@ urlpatterns = [
     path('get_cont/', get_contributor_from_id, name='get_cont'),
     path('get_user_workspaces/',get_workspaces,name='get_user_workspaces'),
     path('get_workspace/',get_workspace_from_id,name='get_workspace'),
+    path('send_collab_req/', send_collaboration_request, name='send_col_req'),
+    path('update_req/', update_request_status, name='update_req'),
+    path('send_rev_req/', send_review_request, name='send_rev_req'),
 ]

--- a/project/backend/api/views.py
+++ b/project/backend/api/views.py
@@ -270,9 +270,12 @@ def get_workspaces(request):
     pending = []
     for req in CollaborationRequest.objects.filter(receiver=cont):
         workspace = req.workspace
-        pending.append({'workspace_id': workspace.workspace_id,
-                               'workspace_title': workspace.workspace_title,
-                               'pending': True})
+        request_id = req.id
+        if req.status == 'P':
+            pending.append({'workspace_id': workspace.workspace_id,
+                                   'workspace_title': workspace.workspace_title,
+                                   'pending': True,
+                            'request_id':request_id})
 
     return JsonResponse({'workspaces':workspace_list,'pending_workspaces':pending}, status=200)
 
@@ -310,10 +313,11 @@ def get_workspace_from_id(request):
     for pend in CollaborationRequest.objects.filter(workspace=workspace):
         cont = pend.receiver
         user = User.objects.get(id=cont.user_id)
-        pending.append({"id": cont.id,
-                         "first_name": user.first_name,
-                         "last_name": user.last_name,
-                         "username": user.username})
+        if pend.status == 'P':
+            pending.append({"id": cont.id,
+                             "first_name": user.first_name,
+                             "last_name": user.last_name,
+                             "username": user.username})
     references = []
     for ref in workspace.references.all():
         authors = []

--- a/project/backend/api/views.py
+++ b/project/backend/api/views.py
@@ -346,3 +346,39 @@ def get_workspace_from_id(request):
                         'references':references,
                          'created_at':workspace.created_at,
                          }, status=200)
+
+@api_view(['POST'])
+def send_collaboration_request(request):
+
+    serializer = CollaborationRequestSerializer(data=request.data)
+    if serializer.is_valid():
+        serializer.save()
+        return Response(serializer.data, status=201)
+    return Response(serializer.errors, status=400)
+
+@api_view(['PUT'])
+def update_request_status(request):
+    try:
+        req = Request.objects.get(pk=request.data.get('workspace_id'))
+    except Request.DoesNotExist:
+        return Response({"message": "Request not found."}, status=404)
+
+    status = request.data.get('status')
+
+    if status not in ["P", "A", "R"]:
+        return Response({"message": "Invalid status value."}, status=400)
+
+    req.status = status
+    req.save()
+
+    serializer = RequestSerializer(req)
+    return Response(serializer.data, status=200)
+
+@api_view(['POST'])
+def send_review_request(request):
+
+    serializer = ReviewRequestSerializer(data=request.data)
+    if serializer.is_valid():
+        serializer.save()
+        return Response(serializer.data, status=201)
+    return Response(serializer.errors, status=400)

--- a/project/backend/database/models.py
+++ b/project/backend/database/models.py
@@ -153,8 +153,6 @@ class Request(models.Model):
 
     sender = models.ForeignKey(Contributor, on_delete=models.PROTECT, related_name="outgoing_requests")
     receiver = models.ForeignKey(Contributor, on_delete=models.PROTECT, related_name="incoming_requests")
-    title = models.CharField(max_length=80)
-    body = models.TextField(max_length=400)
     status = models.CharField(max_length=1, choices=request_status_choices, default="P")
     
     def accept(self):

--- a/project/backend/database/serializers.py
+++ b/project/backend/database/serializers.py
@@ -171,3 +171,18 @@ class NodeSerializer(serializers.ModelSerializer):
     model = Node
     fields = ['node_id', 'node_title', 'publish_date', 'is_valid', 'num_visits' , 'theorem', 'contributors',
                    'reviewers', 'from_referenced_nodes' , 'to_referenced_nodes', 'proofs' , 'question_set', 'semantic_tags', 'wiki_tags', 'annotations']
+
+class RequestSerializer(serializers.ModelSerializer):
+  class Meta:
+    model = Request
+    fields = '__all__'
+
+class CollaborationRequestSerializer(serializers.ModelSerializer):
+  class Meta:
+    model = CollaborationRequest
+    fields = '__all__'
+
+class ReviewRequestSerializer(serializers.ModelSerializer):
+  class Meta:
+    model = ReviewRequest
+    fields = '__all__'

--- a/project/backend/database/tests.py
+++ b/project/backend/database/tests.py
@@ -479,14 +479,12 @@ class RequestModelTestCase(TestCase):
             last_name="Test2",
         )
         self.receiver = Contributor.objects.create(user=receiver_user, bio="Test bio 2")
-        self.request = Request.objects.create(sender=self.sender, receiver=self.receiver, title="Request title", body="Request body")
+        self.request = Request.objects.create(sender=self.sender, receiver=self.receiver)
 
     def test_db(self):
         self.assertGreater(Request.objects.filter(sender=self.sender).count(), 0, "Could not find created request in the db with this sender!")
         req = Request.objects.get(sender=self.sender)
         self.assertEqual(req.receiver.id, self.receiver.id, "Receiver didn't match")
-        self.assertEqual(req.title, self.request.title, "Title didn't match")
-        self.assertEqual(req.body, self.request.body, "Body didn't match")
         self.assertEqual(self.request.status, "P", "Status is not Pending")
 
     def test_accept(self):


### PR DESCRIPTION
Implemented POST and PUT methods for collaboration and review requests to send and update the status. Usage examples are provided in Postman. This PR fixes #445 