### PR TITLE
Role Related Access Control

### DIFF
--- a/project/backend/api/urls.py
+++ b/project/backend/api/urls.py
@@ -15,4 +15,5 @@ urlpatterns = [
     path('get_proof/', get_proof_from_id, name='get_proof'),
     path('get_theorem/', get_theorem_from_id, name='get_theorem'),
     path('get_cont/', get_contributor_from_id, name='get_cont'),
+    path('me/', RoleView.as_view(), name='me'),
 ]

--- a/project/backend/api/urls.py
+++ b/project/backend/api/urls.py
@@ -15,5 +15,4 @@ urlpatterns = [
     path('get_proof/', get_proof_from_id, name='get_proof'),
     path('get_theorem/', get_theorem_from_id, name='get_theorem'),
     path('get_cont/', get_contributor_from_id, name='get_cont'),
-    path('me/', RoleView.as_view(), name='me'),
 ]

--- a/project/backend/api/views.py
+++ b/project/backend/api/views.py
@@ -19,6 +19,25 @@ from database.models import *
 
 # Create your views here.
 
+class RoleView(APIView):
+    authentication_classes = (TokenAuthentication,)
+    permission_classes = (IsAuthenticated,)
+    def get(self, request, *args, **kwargs):
+        user = User.objects.get(id=request.user.id)
+        reviewer = Reviewer.objects.filter(user=user)
+        cont = Contributor.objects.filter(user=user)
+        basic = BasicUser.objects.filter(user=user)
+
+        if reviewer.count() != 0:
+            return JsonResponse({'role': 'reviewer'},status=200)
+        elif cont.count() != 0:
+            return JsonResponse({'role': 'contributor'},status=200)
+        elif basic.count() != 0:
+            return JsonResponse({'role': 'basic_user'},status=200)
+        
+        serializer = UserSerializer(user)
+        return Response(serializer.data)
+
 # Class based view to register user
 class SignUpAPIView(generics.CreateAPIView):
     permission_classes = (AllowAny,) 

--- a/project/backend/api/views.py
+++ b/project/backend/api/views.py
@@ -19,24 +19,19 @@ from database.models import *
 
 # Create your views here.
 
-class RoleView(APIView):
-    authentication_classes = (TokenAuthentication,)
-    permission_classes = (IsAuthenticated,)
-    def get(self, request, *args, **kwargs):
-        user = User.objects.get(id=request.user.id)
-        reviewer = Reviewer.objects.filter(user=user)
-        cont = Contributor.objects.filter(user=user)
-        basic = BasicUser.objects.filter(user=user)
-
-        if reviewer.count() != 0:
-            return JsonResponse({'role': 'reviewer'},status=200)
-        elif cont.count() != 0:
-            return JsonResponse({'role': 'contributor'},status=200)
-        elif basic.count() != 0:
-            return JsonResponse({'role': 'basic_user'},status=200)
-        
-        serializer = UserSerializer(user)
-        return Response(serializer.data)
+def get_user_role_from_request(self, request):
+    user = User.objects.get(id=request.user.id)
+    reviewer = Reviewer.objects.filter(user=user)
+    cont = Contributor.objects.filter(user=user)
+    basic = BasicUser.objects.filter(user=user)
+    if reviewer.count() != 0:
+        return "REVIEWER"
+    elif cont.count() != 0:
+        return "CONTRIBUTOR"
+    elif basic.count() != 0:
+        return "BASICUSER"
+    else:
+        return None
 
 # Class based view to register user
 class SignUpAPIView(generics.CreateAPIView):


### PR DESCRIPTION
A simple method is implemented in order to differentiate user roles from request send. We may call this function before processing each request in every necessary end-point. This is the simplest, most lightweight solution.

Implementing this solution will require us to specify restricted end-points then calling this function in each of them, which I didn't want to start before approval of all you guys. 

This PR closes: #444 