### PR TITLE
configuration of different please login pages and their routing

### DIFF
--- a/project/FrontEnd/collaborative_science_platform/lib/screens/auth_screens/please_login_page.dart
+++ b/project/FrontEnd/collaborative_science_platform/lib/screens/auth_screens/please_login_page.dart
@@ -1,18 +1,16 @@
-import 'package:collaborative_science_platform/screens/auth_screens/login_page.dart';
-import 'package:collaborative_science_platform/screens/auth_screens/signup_page.dart';
+import 'package:collaborative_science_platform/screens/auth_screens/widgets/please_login_signup.dart';
+import 'package:collaborative_science_platform/screens/auth_screens/widgets/please_login_prompts.dart';
 import 'package:collaborative_science_platform/screens/home_page/widgets/home_page_appbar.dart';
 import 'package:collaborative_science_platform/screens/page_with_appbar/page_with_appbar.dart';
-import 'package:collaborative_science_platform/utils/colors.dart';
 import 'package:collaborative_science_platform/utils/responsive/responsive.dart';
 import 'package:flutter/material.dart';
-import 'package:go_router/go_router.dart';
 
-class PleaseLoginPage2 extends StatelessWidget {
+class PleaseLoginPage extends StatelessWidget {
   static const routeName = '/please-login';
-  final String message;
-  const PleaseLoginPage2({
+  final String? pageType;
+  const PleaseLoginPage({
     super.key,
-    required this.message,
+    this.pageType,
   });
 
   @override
@@ -21,76 +19,28 @@ class PleaseLoginPage2 extends StatelessWidget {
       appBar: const HomePageAppBar(),
       child: SizedBox(
         width: Responsive.getGenericPageWidth(context),
-        child: Column(
-          children: <Widget>[
-            const Padding(
-              padding: EdgeInsets.fromLTRB(15.0, 0.0, 15.0, 0.0),
-              child: Divider(height: 40.0),
-            ),
-            Column(
-              mainAxisAlignment: MainAxisAlignment.end,
-              children: <Widget>[
-                SelectableText(message),
-                const SizedBox(height: 5),
-                MouseRegion(
-                  cursor: SystemMouseCursors.click,
-                  child: GestureDetector(
-                    onTap: () => context.go(LoginPage.routeName),
-                    child: Container(
-                      height: 40.0,
-                      width: 160,
-                      decoration: BoxDecoration(
-                          color: Colors.blue, borderRadius: BorderRadius.circular(5.0)),
-                      child: const Row(
-                        mainAxisAlignment: MainAxisAlignment.center,
-                        children: [
-                          Text(
-                            'Login',
-                            style: TextStyle(
-                              color: Colors.white,
-                              fontWeight: FontWeight.bold,
-                              fontSize: 16.0,
-                            ),
-                          ),
-                        ],
-                      ),
-                    ),
-                  ),
+        child: SingleChildScrollView(
+          child: Column(
+            children: <Widget>[
+              const Padding(
+                padding: EdgeInsets.fromLTRB(15.0, 0.0, 15.0, 0.0),
+                child: Divider(height: 40.0),
+              ),
+              if (pageType == "notifications") NotificationExplanation(),
+              if (pageType == "workspaces") WorkspaceExplanation(),
+              if (pageType == "profile") ProfileExplanation(),
+              if (pageType != null)
+                Padding(
+                  padding: EdgeInsets.fromLTRB(15.0, 0.0, 15.0, 0.0),
+                  child: Divider(height: 40.0),
                 ),
-                const SizedBox(height: 10),
-                const SelectableText("If you don't have an account please signup!"),
-                const SizedBox(height: 5),
-                MouseRegion(
-                  cursor: SystemMouseCursors.click,
-                  child: GestureDetector(
-                    onTap: () => context.go(SignUpPage.routeName),
-                    child: Container(
-                      height: 40.0,
-                      width: 160,
-                      decoration: BoxDecoration(
-                          color: AppColors.primaryColor, borderRadius: BorderRadius.circular(5.0)),
-                      child: const Row(
-                        mainAxisAlignment: MainAxisAlignment.center,
-                        children: [
-                          Text('Signup',
-                            style: TextStyle(
-                              color: Colors.white,
-                              fontWeight: FontWeight.bold,
-                              fontSize: 16.0,
-                            ),
-                          ),
-                        ],
-                      ),
-                    ),
-                  ),
-                ),
-              ],
-            ),
-            const Padding(
-              padding: EdgeInsets.fromLTRB(15.0, 0.0, 15.0, 0.0),
-              child: Divider(height: 40.0),
-            ),
-          ],
+              PleaseLoginSignup(),
+              const Padding(
+                padding: EdgeInsets.fromLTRB(15.0, 0.0, 15.0, 0.0),
+                child: Divider(height: 40.0),
+              ),
+            ],
+          ),
         ),
       ),
     );

--- a/project/FrontEnd/collaborative_science_platform/lib/screens/auth_screens/widgets/please_login_prompts.dart
+++ b/project/FrontEnd/collaborative_science_platform/lib/screens/auth_screens/widgets/please_login_prompts.dart
@@ -1,0 +1,136 @@
+import 'package:collaborative_science_platform/utils/colors.dart';
+import 'package:collaborative_science_platform/utils/text_styles.dart';
+import 'package:flutter/material.dart';
+
+class NotificationExplanation extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      mainAxisAlignment: MainAxisAlignment.end,
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: <Widget>[
+        Container(
+          margin: const EdgeInsets.fromLTRB(15.0, 0.0, 15.0, 0.0),
+          child: Text(
+            "Stay connected and informed with notifications! Up-to-date on the activities related to your interests and contributions.",
+            style: TextStyles.title4,
+          ),
+        ),
+        Container(
+          margin: const EdgeInsets.fromLTRB(15.0, 5.0, 15.0, 0.0),
+          child: Text(
+            "including:",
+            style: TextStyle(
+              fontSize: 20,
+              fontWeight: FontWeight.bold,
+              color: AppColors.secondaryDarkColor,
+            ),
+          ),
+        ),
+        SizedBox(height: 8.0), // Add space between texts
+        Container(
+          margin: const EdgeInsets.fromLTRB(15.0, 0.0, 15.0, 0.0),
+          child: Text(
+            '''
+\u2022 Get notified when your questions receive replies, fostering knowledge exchange.
+\u2022 Stay informed when your contributions are reviewed with valuable feedback.
+\u2022 Embrace collaboration! Receive alerts for collaboration requests.
+\u2022 Stay connected when users ask questions about your contributed nodes
+\u2022 Customize your preferences to enhance engagement on our platform!
+             ''',
+            style: TextStyles.bodyBlack,
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class WorkspaceExplanation extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      mainAxisAlignment: MainAxisAlignment.end,
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: <Widget>[
+        Container(
+          margin: const EdgeInsets.fromLTRB(15.0, 0.0, 15.0, 0.0),
+          child: Text(
+            "Workspaces empower your collaborative work, providing a dynamic, flexible and all-in-one hub for your contributions.",
+            style: TextStyles.title4,
+          ),
+        ),
+        Container(
+          margin: const EdgeInsets.fromLTRB(15.0, 5.0, 15.0, 0.0),
+          child: Text(
+            "including:",
+            style: TextStyle(
+              fontSize: 20,
+              fontWeight: FontWeight.bold,
+              color: AppColors.secondaryDarkColor,
+            ),
+          ),
+        ),
+        SizedBox(height: 8.0), // Add space between texts
+        Container(
+          margin: const EdgeInsets.fromLTRB(15.0, 0.0, 15.0, 0.0),
+          child: Text(
+            '''
+\u2022 Send collaboration requests to contributors of your choice.
+\u2022 Add and edit entries collaboratively.
+\u2022 Effortlessly cite references in your work.
+\u2022 Exclusive visibility, ensuring a private space for your team.
+\u2022 Create different workspaces for various projects with diverse contributors.
+             ''',
+            style: TextStyles.bodyBlack,
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class ProfileExplanation extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      mainAxisAlignment: MainAxisAlignment.end,
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: <Widget>[
+        Container(
+          margin: const EdgeInsets.fromLTRB(15.0, 0.0, 15.0, 0.0),
+          child: Text(
+            "Signing up brings a host of benefits",
+            style: TextStyles.title4,
+          ),
+        ),
+        Container(
+          margin: const EdgeInsets.fromLTRB(15.0, 5.0, 15.0, 0.0),
+          child: Text(
+            "including:",
+            style: TextStyle(
+              fontSize: 20,
+              fontWeight: FontWeight.bold,
+              color: AppColors.secondaryDarkColor,
+            ),
+          ),
+        ),
+        SizedBox(height: 8.0), // Add space between texts
+        Container(
+          margin: const EdgeInsets.fromLTRB(15.0, 0.0, 15.0, 0.0),
+          child: Text(
+            '''
+\u2022 Personalize your profile for easy identification by others.
+\u2022 Showcase your activity on your profile.
+\u2022 Explore and connect with like-minded individuals in similar activities.
+\u2022 Enable others to find you easily and engage in meaningful collaborations.
+\u2022 Edit your profile information effortlessly.
+\u2022 Change your password with ease.
+             ''',
+            style: TextStyles.bodyBlack,
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/project/FrontEnd/collaborative_science_platform/lib/screens/auth_screens/widgets/please_login_signup.dart
+++ b/project/FrontEnd/collaborative_science_platform/lib/screens/auth_screens/widgets/please_login_signup.dart
@@ -1,0 +1,75 @@
+import 'package:collaborative_science_platform/screens/auth_screens/login_page.dart';
+import 'package:collaborative_science_platform/screens/auth_screens/signup_page.dart';
+import 'package:collaborative_science_platform/utils/colors.dart';
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+
+class PleaseLoginSignup extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      mainAxisAlignment: MainAxisAlignment.end,
+      children: <Widget>[
+        SelectableText("To be able to see this page, please login!"),
+        const SizedBox(height: 5),
+        MouseRegion(
+          cursor: SystemMouseCursors.click,
+          child: GestureDetector(
+            onTap: () => context.go(LoginPage.routeName),
+            child: Container(
+              height: 40.0,
+              width: 160,
+              decoration: BoxDecoration(
+                color: Colors.blue,
+                borderRadius: BorderRadius.circular(5.0),
+              ),
+              child: const Row(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  Text(
+                    'Login',
+                    style: TextStyle(
+                      color: Colors.white,
+                      fontWeight: FontWeight.bold,
+                      fontSize: 16.0,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+        const SizedBox(height: 10),
+        const SelectableText("If you don't have an account please"),
+        const SizedBox(height: 5),
+        MouseRegion(
+          cursor: SystemMouseCursors.click,
+          child: GestureDetector(
+            onTap: () => context.go(SignUpPage.routeName),
+            child: Container(
+              height: 40.0,
+              width: 160,
+              decoration: BoxDecoration(
+                color: AppColors.primaryColor,
+                borderRadius: BorderRadius.circular(5.0),
+              ),
+              child: const Row(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  Text(
+                    'Signup',
+                    style: TextStyle(
+                      color: Colors.white,
+                      fontWeight: FontWeight.bold,
+                      fontSize: 16.0,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/project/FrontEnd/collaborative_science_platform/lib/screens/page_with_appbar/widgets/top_navigation_bar.dart
+++ b/project/FrontEnd/collaborative_science_platform/lib/screens/page_with_appbar/widgets/top_navigation_bar.dart
@@ -81,13 +81,6 @@ class _NavigationBarItemState extends State<NavigationBarItem> {
       child: GestureDetector(
         onTap: () {
           ScreenTab selected = widget.value;
-          if (selected == ScreenTab.profile || selected == ScreenTab.workspaces ||
-              selected == ScreenTab.workspace || selected == ScreenTab.createWorkspace ||
-              selected == ScreenTab.notifications) {
-            if (!Provider.of<Auth>(context, listen: false).isSignedIn) {
-              selected = ScreenTab.pleaseLogin;
-            }
-          }
           if (selected == ScreenTab.profile) {
             Provider.of<ScreenNavigation>(context, listen: false).setSelectedTab(selected, context,
                 email: Uri.decodeComponent(Provider.of<Auth>(context, listen: false).user!.email));

--- a/project/FrontEnd/collaborative_science_platform/lib/screens/profile_page/widgets/logout_button.dart
+++ b/project/FrontEnd/collaborative_science_platform/lib/screens/profile_page/widgets/logout_button.dart
@@ -12,7 +12,7 @@ class LogOutButton extends StatelessWidget {
       child: GestureDetector(
         onTap: () {
           Provider.of<Auth>(context, listen: false).logout();
-          context.go(PleaseLoginPage2.routeName);
+          context.go(PleaseLoginPage.routeName);
         },
         child: Container(
           height: 40.0,

--- a/project/FrontEnd/collaborative_science_platform/lib/services/screen_navigation.dart
+++ b/project/FrontEnd/collaborative_science_platform/lib/services/screen_navigation.dart
@@ -53,7 +53,7 @@ class ScreenNavigation extends ChangeNotifier {
         context.go('${ProfilePage.routeName}/$email');
         break;
       case ScreenTab.pleaseLogin:
-        context.go(PleaseLoginPage2.routeName);
+        context.go(PleaseLoginPage.routeName);
         break;
       case ScreenTab.none:
         break;

--- a/project/FrontEnd/collaborative_science_platform/lib/utils/router.dart
+++ b/project/FrontEnd/collaborative_science_platform/lib/utils/router.dart
@@ -62,8 +62,7 @@ final router = GoRouter(
         },
         redirect: (context, state) {
           if (!context.read<Auth>().isSignedIn) {
-            // please login
-            return LoginPage.routeName;
+            return '${PleaseLoginPage.routeName}${WorkspacesPage.routeName}';
           } else {
             return null;
           }
@@ -109,6 +108,13 @@ final router = GoRouter(
       name: NotificationPage.routeName.substring(1),
       path: NotificationPage.routeName,
       builder: (context, state) => const NotificationPage(),
+      redirect: (context, state) {
+        if (!context.read<Auth>().isSignedIn) {
+          return '${PleaseLoginPage.routeName}${NotificationPage.routeName}';
+        } else {
+          return null;
+        }
+      },
     ),
     GoRoute(
       name: AccountSettingsPage.routeName.substring(1),
@@ -116,11 +122,17 @@ final router = GoRouter(
       builder: (context, state) => const AccountSettingsPage(),
     ),
     GoRoute(
-      name: PleaseLoginPage2.routeName.substring(1),
-      path: PleaseLoginPage2.routeName,
-      // Different login messages might be given for difference pages
-      builder: (context, state) =>
-          const PleaseLoginPage2(message: "To be able to see this page, please login!"),
+      name: "/please-login",
+      path: PleaseLoginPage.routeName,
+      builder: (context, state) => const PleaseLoginPage(),
+    ),
+    GoRoute(
+      name: PleaseLoginPage.routeName.substring(1),
+      path: "${PleaseLoginPage.routeName}/:pageType",
+      builder: (context, state) {
+        final String pageType = state.pathParameters['pageType'] ?? '';
+        return PleaseLoginPage(pageType: pageType);
+      },
     ),
     GoRoute(
       name: NodeDetailsPage.routeName.substring(1),
@@ -131,12 +143,21 @@ final router = GoRouter(
       },
     ),
     GoRoute(
-        name: ProfilePage.routeName.substring(1),
-        path: "${ProfilePage.routeName}/:email",
-        builder: (context, state) {
-          final String encodedEmail = state.pathParameters['email'] ?? '';
-          final String email = Uri.decodeComponent(encodedEmail);
-          return ProfilePage(email: email);
-        }),
+      name: ProfilePage.routeName.substring(1),
+      path: "${ProfilePage.routeName}/:email",
+      builder: (context, state) {
+        final String encodedEmail = state.pathParameters['email'] ?? '';
+        final String email = Uri.decodeComponent(encodedEmail);
+        return ProfilePage(email: email);
+      },
+      redirect: (context, state) {
+        if (!context.read<Auth>().isSignedIn &&
+            (state.pathParameters['email'] == null || state.pathParameters['email'] == '')) {
+          return '${PleaseLoginPage.routeName}${ProfilePage.routeName}';
+        } else {
+          return null;
+        }
+      },
+    ),
   ],
 );


### PR DESCRIPTION
## Changes
Name change
- changed PleaseLoginPage2 to PleaseLoginPage in order to prevent confusions

New files
- _lib/screens/auth_screens/widgets/please_login_prompts:_ contents which explains usage and aim of different pages: _notifications_, _workspaces_, and _profile_
- _lib/screens/auth_screens/widgets/please_login_signup:_ login and signup buttons in previous version of please login page is rewritten as widget in the same format

Router related
- added to /please-login and so PleaseLoginPage class a pathParameter namely, **_pageType_**
- redirected workspaces, notifications, and only '/profile' (as own profile page) to PleaseLoginPage with related pageType
- removed redirection in appBar since it's redundant and also prevents redirection logic in router

## Testing 
manual, but recognized couple of things related to appBar:
- profile in appBar is not working on mobile
- notification in appBar is not working on web
all my URL tests and working appBar parts behaved as expected