### PR TITLE
Implement disproof functionality

### DIFF
--- a/project/backend/api/tests.py
+++ b/project/backend/api/tests.py
@@ -1014,3 +1014,62 @@ class AddUserSemanticTagTestCase(TestCase):
         }
         response = self.client.post(url, payload, format='json')
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+
+class WorkspaceProofTestCase(TestCase):
+    def setUp(self):
+        
+        self.user_for_contributor = User.objects.create_user(id=3, email= 'cont@example.com', username='cont@example.com', first_name='Contributor User', last_name='Test')
+        self.contributor = Contributor.objects.create(user=self.user_for_contributor, bio="I am the contributor")
+
+        self.client = APIClient()
+      
+        self.cont_token = Token.objects.create(user=self.user_for_contributor)
+        self.client.credentials(HTTP_AUTHORIZATION=f"Token {self.cont_token.key}")
+
+        self.entry = Entry.objects.create(entry_id = 1)
+        self.workspace = Workspace.objects.create(workspace_id=1)
+
+        self.workspace.entries.add(self.entry)
+
+        self.contributor.workspaces.add(self.workspace)
+
+    def tearDown(self):
+        Entry.objects.all().delete()
+        Workspace.objects.all().delete()
+        Contributor.objects.all().delete()
+        User.objects.all().delete()
+        Token.objects.all().delete()
+
+        print("All tests for setting/removing workspace proof are completed!")
+
+
+    def test_set_workspace_proof(self):
+        url = reverse('set_workspace_proof')
+        data = {
+            'workspace_id': self.workspace.workspace_id,
+            'entry_id': self.entry.entry_id,
+            'is_disproof': True,
+        }
+
+        response = self.client.post(url, data=data)
+
+        self.assertEqual(response.status_code, 200, response.json())
+        
+        self.assertEqual(Workspace.objects.get(pk=self.workspace.workspace_id).proof_entry.entry_id, self.entry.entry_id)
+        self.assertEqual(Entry.objects.get(pk=self.entry.entry_id).is_proof_entry, True)
+        self.assertEqual(Entry.objects.get(pk=self.entry.entry_id).is_disproof_entry, True)
+
+    
+    def test_remove_workspace_proof(self):
+        url = reverse('remove_workspace_proof')
+        data = {
+            'workspace_id': self.workspace.workspace_id,
+        }
+
+        response = self.client.post(url, data=data)
+
+        self.assertEqual(response.status_code, 200, response.json())
+
+        self.assertIsNone(Workspace.objects.get(pk=self.workspace.workspace_id).proof_entry)
+        self.assertEqual(Entry.objects.get(pk=self.entry.entry_id).is_proof_entry, False)
+        self.assertEqual(Entry.objects.get(pk=self.entry.entry_id).is_disproof_entry, False)

--- a/project/backend/api/views.py
+++ b/project/backend/api/views.py
@@ -625,6 +625,7 @@ def change_workspace_title(request):
 def set_workspace_proof(request):
     entry_id = request.POST.get("entry_id")
     workspace_id = request.POST.get("workspace_id")
+    is_disproof = request.POST.get("is_disproof")
     if entry_id == None or entry_id == '':
         return JsonResponse({'message': 'entry_id field can not be empty'}, status=400)
     try:
@@ -660,6 +661,8 @@ def set_workspace_proof(request):
         workspace.proof_entry.is_proof_entry = False
     workspace.proof_entry = entry
     entry.is_proof_entry = True
+    if is_disproof:
+        entry.is_disproof_entry= True
     entry.save()
     workspace.save()
     return JsonResponse({'message': 'Proof entry is successfully set.'}, status=200)
@@ -693,9 +696,11 @@ def remove_workspace_proof(request):
         return JsonResponse({'message': 'Workspace is already finalized'}, status=403)
     if workspace.proof_entry != None:
         workspace.proof_entry.is_proof_entry = False
+        workspace.proof_entry.is_disproof_entry = False
+        workspace.proof_entry.save()
     workspace.proof_entry = None
     workspace.save()
-    return JsonResponse({'message': 'Theorem entry is successfully removed.'}, status=200)
+    return JsonResponse({'message': 'Proof entry is successfully removed.'}, status=200)
 
 
 @csrf_exempt
@@ -1247,7 +1252,7 @@ def update_review_request_status(request):
                                     proof_title="",
                                     proof_content=entry.content,
                                     is_valid=True,
-                                    is_disproof=False,
+                                    is_disproof= entry.is_disproof_entry,
                                     publish_date=datetime.date.today(),
                                     removed_by_admin=False,
                                     node=node,

--- a/project/backend/api/views.py
+++ b/project/backend/api/views.py
@@ -1103,15 +1103,6 @@ def get_random_node_id(request):
         node_list.append(node_ids[index])
     return JsonResponse({'node_ids': node_list}, status=200)
 
-
-class IsContributor(BasePermission):
-    def has_permission(self, request, view):
-        if not request.user.is_authenticated:
-            return False
-        if not Contributor.objects.filter(pk=request.user.basicuser.pk).exists():
-            return False
-        return True
-
 @authentication_classes((TokenAuthentication,))
 @permission_classes((IsAuthenticated, IsContributor))
 @api_view(['POST'])

--- a/project/backend/database/models.py
+++ b/project/backend/database/models.py
@@ -65,6 +65,7 @@ class Entry(models.Model):
     is_theorem_entry = models.BooleanField(default=False)
     is_final_entry = models.BooleanField(default=False)
     is_proof_entry = models.BooleanField(default=False)
+    is_disproof_entry = models.BooleanField(default=False)
     is_editable = models.BooleanField(default=True)
     #creator = models.ForeignKey(Contributor,null=True,blank=True, on_delete = models.CASCADE)
     entry_number = models.IntegerField(blank=True,null=True)


### PR DESCRIPTION
Added is_disproof field to Entry model.
Updated set_workspace_proof function to also get the is_disproof value from the request. If an entry is chosen as disproof, the Entry model will update its is_disproof filed as True.

Migrations should be made after this PR. This PR fixes #661 