### PR TITLE
Semantic tag post api and remove workspace tag put api

### DIFF
--- a/project/backend/api/urls.py
+++ b/project/backend/api/urls.py
@@ -46,4 +46,6 @@ urlpatterns = [
     path('promote_contributor/', promote_contributor, name='promote_contributor'),
     path('demote_reviewer/', demote_reviewer, name='demote_reviewer'),
     path('add_user_semantic_tag/', AddUserSemanticTag.as_view(), name='add_user_semantic_tag'),
+    path('add_semantic_tag/', SemanticTagAPIView.as_view(), name='add_semantic_tag'),
+
 ]

--- a/project/backend/api/urls.py
+++ b/project/backend/api/urls.py
@@ -47,5 +47,6 @@ urlpatterns = [
     path('demote_reviewer/', demote_reviewer, name='demote_reviewer'),
     path('add_user_semantic_tag/', AddUserSemanticTag.as_view(), name='add_user_semantic_tag'),
     path('add_semantic_tag/', SemanticTagAPIView.as_view(), name='add_semantic_tag'),
+    path('remove_workspace_tag/', remove_workspace_tag, name='remove_workspace_tag'),
 
 ]

--- a/project/backend/api/views.py
+++ b/project/backend/api/views.py
@@ -132,7 +132,18 @@ class WorkspacePostAPIView(APIView):
             serializer.errors, status=400
         )
 
+class SemanticTagAPIView(APIView):
+    authentication_classes = (TokenAuthentication,)
+    permission_classes = (IsAuthenticated, IsContributorAndWorkspace)
 
+    def post(self, request):
+        serializer = SemanticTagSerializer(data=request.data, context={'request': request})
+        if serializer.is_valid():
+            serializer.save()
+            return Response(serializer.data, status=201)
+        return Response(
+            serializer.errors, status=400
+        )
 
 def search(request):
 

--- a/project/backend/api/views.py
+++ b/project/backend/api/views.py
@@ -145,6 +145,42 @@ class SemanticTagAPIView(APIView):
             serializer.errors, status=400
         )
 
+def is_workspace_contributor(request):
+    workspace_id = request.data.get('workspace_id')
+    if not request.user.is_authenticated:
+        return False
+    if not Contributor.objects.filter(pk=request.user.basicuser.pk).exists():
+        return False
+    if workspace_id is not None:
+        return request.user.basicuser.contributor.workspaces.filter(workspace_id=workspace_id).exists()
+    return True
+
+@api_view(['PUT'])
+def remove_workspace_tag(request):
+    workspace_id = request.data.get("workspace_id")
+    tag_id = request.data.get("tag_id")
+
+    if workspace_id == None or workspace_id == '':
+        return JsonResponse({'message': 'workspace_id field can not be empty'}, status=400)
+    try:
+        workspace_id = int(workspace_id)
+    except:
+        return JsonResponse({'message': 'workspace_id  field has to be an integer'}, status=400)
+    
+    if tag_id == None or tag_id == '':
+        return JsonResponse({'message': 'tag_id field can not be empty'}, status=400)
+    try:
+        tag_id = int(tag_id)
+    except:
+        return JsonResponse({'message': 'tag_id  field has to be an integer'}, status=400)
+
+    if is_workspace_contributor(request):
+        workspace = Workspace.objects.get(workspace_id=workspace_id)
+        workspace.semantic_tags.remove(tag_id)
+        return JsonResponse({'message': 'Tag is successfully removed from workspace.'}, status=200)
+    else:
+        return JsonResponse({'message': "You don't have permission to do this!"}, status=403)
+
 def search(request):
 
     search = request.GET.get("query")

--- a/project/backend/database/models.py
+++ b/project/backend/database/models.py
@@ -10,7 +10,7 @@ from api.wikidata import *
 class SemanticTag(models.Model):
     created_at = models.DateTimeField(auto_now_add=True)
     wid = models.CharField(max_length=20)
-    label = models.CharField(max_length=30, unique=True)
+    label = models.CharField(max_length=30)
     
     @property
     def nodes(self):

--- a/project/backend/database/serializers.py
+++ b/project/backend/database/serializers.py
@@ -79,7 +79,7 @@ class SemanticTagSerializer(serializers.ModelSerializer):
     def create(self, validated_data):
       wid = validated_data.get('wid', None)
       label = validated_data.get('label', None)
-      workspace_id = self.context['request'].POST.get('workspace_id', None)
+      workspace_id = self.context['request'].data.get('workspace_id', None)
 
       tag = SemanticTag.objects.create(wid=wid, label=label)
 

--- a/project/backend/database/serializers.py
+++ b/project/backend/database/serializers.py
@@ -68,6 +68,26 @@ class WorkspaceSerializer(serializers.ModelSerializer):
 
       return workspace
 
+class SemanticTagSerializer(serializers.ModelSerializer):
+    wid = serializers.CharField(required=True)
+    label = serializers.CharField(required=True)
+
+    class Meta:
+        model = SemanticTag
+        fields = "__all__"
+
+    def create(self, validated_data):
+      wid = validated_data.get('wid', None)
+      label = validated_data.get('label', None)
+      workspace_id = self.context['request'].POST.get('workspace_id', None)
+
+      tag = SemanticTag.objects.create(wid=wid, label=label)
+
+      if workspace_id is not None:
+        workspace = Workspace.objects.get(workspace_id=workspace_id)
+        workspace.semantic_tags.add(tag)
+
+      return tag
 
 # Serializer to change password
 class ChangePasswordSerializer(serializers.ModelSerializer):


### PR DESCRIPTION
In this pull request I implemented a POST API for creating a semantic tag and adding it to a workspace if workspace_id is specified just after creation. Also, I implemented another API for removing a tag from a workspace. The latter one was planned as deleting a semantic tag. However, the plans has changed since removing the tag from workspace is a better approach than deleting the semantic tag entirely.

I also implemented the tests for both APIs. I tested the APIs manually too. Everything works properly.

Successful merge of this pull request closes #665 and closes #666 