### PR TITLE
bug fix for showing multiple proofs

### DIFF
--- a/project/FrontEnd/collaborative_science_platform/lib/screens/node_details_page/widgets/proof_list_view.dart
+++ b/project/FrontEnd/collaborative_science_platform/lib/screens/node_details_page/widgets/proof_list_view.dart
@@ -11,6 +11,7 @@ import 'dart:convert';
 
 class ProofListView extends StatefulWidget {
   final List<Proof> proof;
+
   const ProofListView({super.key, required this.proof});
 
   @override
@@ -18,92 +19,122 @@ class ProofListView extends StatefulWidget {
 }
 
 class _ProofListViewState extends State<ProofListView> {
-  bool showAnnotations = false;
   @override
   Widget build(BuildContext context) {
     return Container(
       width: Responsive.desktopPageWidth,
       decoration: BoxDecoration(color: Colors.grey[200]),
-      child: ListView.builder(
-          scrollDirection: Axis.vertical,
-          shrinkWrap: true,
-          padding: const EdgeInsets.all(8),
-          itemCount: widget.proof.length,
-          itemBuilder: (BuildContext context, int index) {
-            return Padding(
-              padding: const EdgeInsets.all(5),
-              child: CardContainer(
-                child: Column(
-                  mainAxisAlignment: MainAxisAlignment.start,
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    // Text(
-                    //   proof[index].isDisproof ? "Disproof" : "Proof",
-                    //   style: TextStyles.bodyGrey,
-                    //   textAlign: TextAlign.start,
-                    // ),
-                    // Text(
-                    //   proof[index].proofTitle,
-                    //   style: TextStyles.title4,
-                    //   textAlign: TextAlign.start,
-                    // ),
-                    Row(
-                      mainAxisAlignment: MainAxisAlignment.end,
-                      children: [
-                        SizedBox(
-                            width: 180,
-                            child: AppButton(
-                                text: showAnnotations ? "Show Text" : "Show Annotations",
-                                height: 40,
-                                onTap: () {
-                                  setState(() {
-                                    showAnnotations = !showAnnotations;
-                                  });
-                                })),
-                      ],
-                    ),
-                    const SizedBox(height: 8),
-                    showAnnotations
-                        ? AnnotationText(
-                            utf8.decode(widget.proof[index].proofContent.codeUnits),
-                            annotationType: AnnotationType.proof,
-                          )
-                        : TeXView(
-                            renderingEngine: const TeXViewRenderingEngine.katex(),
-                            child: TeXViewDocument(
-                                utf8.decode(widget.proof[index].proofContent.codeUnits))),
+      child: SingleChildScrollView(
+        child: Column(
+          children: widget.proof.map((proof) => ProofItemWidget(proof: proof)).toList(),
+        ),
+      ),
+    );
+  }
+}
 
-                    // Row(
-                    //   mainAxisAlignment: MainAxisAlignment.end,
-                    //   crossAxisAlignment: CrossAxisAlignment.end,
-                    //   children: [
-                    //     Icon(
-                    //       proof[index].isValid ? Icons.check : Icons.clear,
-                    //       color: proof[index].isValid ? AppColors.successColor : AppColors.dangerColor,
-                    //     ),
-                    //     Text(
-                    //       proof[index].isValid ? "valid" : "invalid",
-                    //       style: TextStyles.bodyGrey,
-                    //       textAlign: TextAlign.end,
-                    //     ),
-                    //   ],
-                    // ),
-                    Row(
-                      mainAxisAlignment: MainAxisAlignment.end,
-                      crossAxisAlignment: CrossAxisAlignment.end,
-                      children: [
-                        Text(
-                          widget.proof[index].publishDate.toString(),
-                          style: TextStyles.bodyGrey,
-                          textAlign: TextAlign.end,
-                        )
-                      ],
-                    ),
-                  ],
+class ProofItemWidget extends StatefulWidget {
+  final Proof proof;
+
+  ProofItemWidget({Key? key, required this.proof}) : super(key: key);
+
+  @override
+  _ProofItemWidgetState createState() => _ProofItemWidgetState();
+}
+
+class _ProofItemWidgetState extends State<ProofItemWidget> {
+  bool showAnnotations = true;
+  bool isLoaded = false;
+
+  @override
+  void initState() {
+    super.initState();
+    // Delay the rendering of TeXView
+    Future.delayed(Duration(milliseconds: 500), () {
+      if (mounted) {
+        setState(() {
+          isLoaded = true;
+        });
+      }
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.all(5),
+      child: CardContainer(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.start,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            // Text(
+            //   proof[index].isDisproof ? "Disproof" : "Proof",
+            //   style: TextStyles.bodyGrey,
+            //   textAlign: TextAlign.start,
+            // ),
+            // Text(
+            //   proof[index].proofTitle,
+            //   style: TextStyles.title4,
+            //   textAlign: TextAlign.start,
+            // ),
+            // Conditional rendering based on isLoaded
+            Row(
+              mainAxisAlignment: MainAxisAlignment.end,
+              children: [
+                SizedBox(
+                  width: 180,
+                  child: AppButton(
+                      text: showAnnotations ? "Show Text" : "Show Annotations",
+                      height: 40,
+                      onTap: () {
+                        setState(() {
+                          showAnnotations = !showAnnotations;
+                        });
+                      }),
                 ),
-              ),
-            );
-          }),
+              ],
+            ),
+            const SizedBox(height: 8),
+            showAnnotations
+                ? AnnotationText(
+                    utf8.decode(widget.proof.proofContent.codeUnits),
+                    annotationType: AnnotationType.proof,
+                  )
+                : isLoaded
+                    ? TeXView(
+                        renderingEngine: const TeXViewRenderingEngine.katex(),
+                        child: TeXViewDocument(utf8.decode(widget.proof.proofContent.codeUnits)))
+                    : SizedBox.shrink(),
+            // Row(
+            //   mainAxisAlignment: MainAxisAlignment.end,
+            //   crossAxisAlignment: CrossAxisAlignment.end,
+            //   children: [
+            //     Icon(
+            //       proof[index].isValid ? Icons.check : Icons.clear,
+            //       color: proof[index].isValid ? AppColors.successColor : AppColors.dangerColor,
+            //     ),
+            //     Text(
+            //       proof[index].isValid ? "valid" : "invalid",
+            //       style: TextStyles.bodyGrey,
+            //       textAlign: TextAlign.end,
+            //     ),
+            //   ],
+            // ),
+            Row(
+              mainAxisAlignment: MainAxisAlignment.end,
+              crossAxisAlignment: CrossAxisAlignment.end,
+              children: [
+                Text(
+                  widget.proof.publishDate.toString(),
+                  style: TextStyles.bodyGrey,
+                  textAlign: TextAlign.end,
+                )
+              ],
+            ),
+          ],
+        ),
+      ),
     );
   }
 }

--- a/project/FrontEnd/collaborative_science_platform/lib/screens/node_details_page/widgets/proof_list_view.dart
+++ b/project/FrontEnd/collaborative_science_platform/lib/screens/node_details_page/widgets/proof_list_view.dart
@@ -19,66 +19,15 @@ class ProofListView extends StatefulWidget {
 }
 
 class _ProofListViewState extends State<ProofListView> {
+  bool showAnnotations = false;
   @override
   Widget build(BuildContext context) {
     return Container(
-      width: Responsive.desktopPageWidth,
+      width: Responsive.desktopPageWidth - 50,
       decoration: BoxDecoration(color: Colors.grey[200]),
       child: SingleChildScrollView(
         child: Column(
-          children: widget.proof.map((proof) => ProofItemWidget(proof: proof)).toList(),
-        ),
-      ),
-    );
-  }
-}
-
-class ProofItemWidget extends StatefulWidget {
-  final Proof proof;
-
-  ProofItemWidget({Key? key, required this.proof}) : super(key: key);
-
-  @override
-  _ProofItemWidgetState createState() => _ProofItemWidgetState();
-}
-
-class _ProofItemWidgetState extends State<ProofItemWidget> {
-  bool showAnnotations = true;
-  bool isLoaded = false;
-
-  @override
-  void initState() {
-    super.initState();
-    // Delay the rendering of TeXView
-    Future.delayed(Duration(milliseconds: 500), () {
-      if (mounted) {
-        setState(() {
-          isLoaded = true;
-        });
-      }
-    });
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    return Padding(
-      padding: const EdgeInsets.all(5),
-      child: CardContainer(
-        child: Column(
-          mainAxisAlignment: MainAxisAlignment.start,
-          crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            // Text(
-            //   proof[index].isDisproof ? "Disproof" : "Proof",
-            //   style: TextStyles.bodyGrey,
-            //   textAlign: TextAlign.start,
-            // ),
-            // Text(
-            //   proof[index].proofTitle,
-            //   style: TextStyles.title4,
-            //   textAlign: TextAlign.start,
-            // ),
-            // Conditional rendering based on isLoaded
             Row(
               mainAxisAlignment: MainAxisAlignment.end,
               children: [
@@ -95,46 +44,85 @@ class _ProofItemWidgetState extends State<ProofItemWidget> {
                 ),
               ],
             ),
-            const SizedBox(height: 8),
             showAnnotations
-                ? AnnotationText(
-                    utf8.decode(widget.proof.proofContent.codeUnits),
-                    annotationType: AnnotationType.proof,
-                  )
-                : isLoaded
-                    ? TeXView(
-                        renderingEngine: const TeXViewRenderingEngine.katex(),
-                        child: TeXViewDocument(utf8.decode(widget.proof.proofContent.codeUnits)))
-                    : SizedBox.shrink(),
-            // Row(
-            //   mainAxisAlignment: MainAxisAlignment.end,
-            //   crossAxisAlignment: CrossAxisAlignment.end,
-            //   children: [
-            //     Icon(
-            //       proof[index].isValid ? Icons.check : Icons.clear,
-            //       color: proof[index].isValid ? AppColors.successColor : AppColors.dangerColor,
-            //     ),
-            //     Text(
-            //       proof[index].isValid ? "valid" : "invalid",
-            //       style: TextStyles.bodyGrey,
-            //       textAlign: TextAlign.end,
-            //     ),
-            //   ],
-            // ),
-            Row(
-              mainAxisAlignment: MainAxisAlignment.end,
-              crossAxisAlignment: CrossAxisAlignment.end,
-              children: [
-                Text(
-                  widget.proof.publishDate.toString(),
-                  style: TextStyles.bodyGrey,
-                  textAlign: TextAlign.end,
-                )
-              ],
-            ),
+                ? ProofItemWidget(proof: widget.proof)
+                : ProofTexView(proof: widget.proof),
           ],
         ),
       ),
+    );
+  }
+}
+
+class ProofTexView extends StatelessWidget {
+  final List<Proof> proof;
+  const ProofTexView({
+    super.key,
+    required this.proof,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return TeXView(
+      renderingEngine: const TeXViewRenderingEngine.katex(),
+      child: TeXViewColumn(
+        children: [
+          for (int i = 0; i < proof.length; i++)
+            TeXViewContainer(
+              child: TeXViewDocument(
+                proof[i].proofContent,
+              ),
+              style: const TeXViewStyle(
+                margin: TeXViewMargin.all(10),
+                elevation: 5,
+                padding: TeXViewPadding.all(16),
+                borderRadius: TeXViewBorderRadius.all(5),
+                backgroundColor: Colors.white,
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+}
+
+class ProofItemWidget extends StatelessWidget {
+  final List<Proof> proof;
+
+  const ProofItemWidget({Key? key, required this.proof}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        for (int i = 0; i < proof.length; i++)
+          Padding(
+            padding: const EdgeInsets.all(5),
+            child: CardContainer(
+              child: Column(
+                mainAxisAlignment: MainAxisAlignment.start,
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  AnnotationText(
+                    utf8.decode(proof[i].proofContent.codeUnits),
+                    annotationType: AnnotationType.proof,
+                  ),
+                  Row(
+                    mainAxisAlignment: MainAxisAlignment.end,
+                    crossAxisAlignment: CrossAxisAlignment.end,
+                    children: [
+                      Text(
+                        proof[i].publishDate.toString(),
+                        style: TextStyles.bodyGrey,
+                        textAlign: TextAlign.end,
+                      )
+                    ],
+                  ),
+                ],
+              ),
+            ),
+          ),
+      ],
     );
   }
 }


### PR DESCRIPTION
### **Issue**

When there is more than one proof for a node, only last one is visible in latex and others seen as blank.

**Problem**: rendering issue of flutter_tex

### **Possible Root Causes & Tried Solutions**
- giving time for rendering as delay (was not sufficient alone)
- ListView.builder may cause an issue due to stateful widget so I changed it to non-built in customize list (was not sufficient alone)
- in order to give time for rendering and also enhance user-friendliness(1 tasla 2 kus), I changed the functionality of `show annotation/show text` buttons, now they are working for each proof independently. (probably this one is the real solver)