### PR TITLE
Provider for GET and POST annotations

### DIFF
--- a/project/FrontEnd/collaborative_science_platform/lib/models/annotation.dart
+++ b/project/FrontEnd/collaborative_science_platform/lib/models/annotation.dart
@@ -6,6 +6,8 @@ class Annotation {
 //  Object annotationLocation;
   String annotationContent;
   String annotationAuthor;
+  String
+      sourceLocation; // http://13.51.205.39/node/{nodeId}%23{theorem|proof}%23{theoremId|proofId}
   int startOffset;
   int endOffset;
 
@@ -15,5 +17,6 @@ class Annotation {
     required this.endOffset,
     required this.annotationContent,
     required this.annotationAuthor,
+    required this.sourceLocation,
   });
 }

--- a/project/FrontEnd/collaborative_science_platform/lib/models/annotation.dart
+++ b/project/FrontEnd/collaborative_science_platform/lib/models/annotation.dart
@@ -7,7 +7,7 @@ class Annotation {
   String annotationContent;
   String annotationAuthor;
   String
-      sourceLocation; // http://13.51.205.39/node/{nodeId}%23{theorem|proof}%23{theoremId|proofId}
+      sourceLocation; // ${Constants.appUrl}/node/{nodeId}%23{theorem|proof}%23{theoremId|proofId}
   int startOffset;
   int endOffset;
 

--- a/project/FrontEnd/collaborative_science_platform/lib/models/annotation.dart
+++ b/project/FrontEnd/collaborative_science_platform/lib/models/annotation.dart
@@ -10,6 +10,7 @@ class Annotation {
       sourceLocation; // ${Constants.appUrl}/node/{nodeId}%23{theorem|proof}%23{theoremId|proofId}
   int startOffset;
   int endOffset;
+  DateTime dateCreated;
 
   Annotation({
     this.annotationID,
@@ -18,5 +19,6 @@ class Annotation {
     required this.annotationContent,
     required this.annotationAuthor,
     required this.sourceLocation,
+    required this.dateCreated,
   });
 }

--- a/project/FrontEnd/collaborative_science_platform/lib/providers/annotation_provider.dart
+++ b/project/FrontEnd/collaborative_science_platform/lib/providers/annotation_provider.dart
@@ -152,12 +152,22 @@ class AnnotationProvider with ChangeNotifier {
     }
   }
 
-/*
-  Future<void> updateAnnotation(Annotation annotation, String text) async {
-    final index =
-        _annotations.indexWhere((element) => element.annotationID == annotation.annotationID);
-    _annotations[index].annotationContent = text;
-    notifyListeners();
+  Future<void> deleteAnnotation(Annotation annotation) async {
+    Uri url =
+        Uri.parse("${Constants.annotationUrl}/annotations/annotation/${annotation.annotationID}");
+    try {
+      var response = await http.delete(url);
+      print(response.statusCode);
+      print(response.body);
+      if (response.statusCode == 204 || response.statusCode == 201 || response.statusCode == 200) {
+        print("Annotation deleted");
+        _annotations.remove(annotation);
+        notifyListeners();
+      } else {
+        throw Exception("Something has happened");
+      }
+    } catch (e) {
+      rethrow;
+    }
   }
-*/
 }

--- a/project/FrontEnd/collaborative_science_platform/lib/providers/annotation_provider.dart
+++ b/project/FrontEnd/collaborative_science_platform/lib/providers/annotation_provider.dart
@@ -37,7 +37,10 @@ class AnnotationProvider with ChangeNotifier {
 
     try {
       var response = await http.get(Uri.parse(finalUrl));
-      if (jsonDecode(response.body)['message'] == "No annotation found!") {
+      // print(response.body);
+      // print(response.statusCode);
+      if (response.statusCode == 404) {
+        // no annotations found
         _annotations.clear();
         notifyListeners();
         return;
@@ -49,8 +52,9 @@ class AnnotationProvider with ChangeNotifier {
 
         // Parse each JSON object into an Annotation and add to _annotations
         for (var annotationJson in annotationsJson) {
+          Uri idUri = Uri.parse(annotationJson['id']);
           _annotations.add(Annotation(
-            annotationID: int.tryParse(annotationJson['id'].pathSegments.last) ??
+            annotationID: int.tryParse(idUri.pathSegments.last) ??
                 -1, // Adjust according to your JSON structure
             startOffset: annotationJson['target']['selector']['start'],
             endOffset: annotationJson['target']['selector']['end'],
@@ -58,6 +62,7 @@ class AnnotationProvider with ChangeNotifier {
             annotationAuthor: annotationJson['creator']['id'],
             sourceLocation: annotationJson['target']['id'],
           ));
+          print(annotationJson['body']['value']);
         }
         notifyListeners();
       } else {

--- a/project/FrontEnd/collaborative_science_platform/lib/providers/annotation_provider.dart
+++ b/project/FrontEnd/collaborative_science_platform/lib/providers/annotation_provider.dart
@@ -61,6 +61,7 @@ class AnnotationProvider with ChangeNotifier {
             annotationContent: annotationJson['body']['value'],
             annotationAuthor: annotationJson['creator']['id'],
             sourceLocation: annotationJson['target']['id'],
+            dateCreated: DateTime.parse(annotationJson['created']),
           ));
           print(annotationJson['body']['value']);
         }

--- a/project/FrontEnd/collaborative_science_platform/lib/providers/annotation_provider.dart
+++ b/project/FrontEnd/collaborative_science_platform/lib/providers/annotation_provider.dart
@@ -37,7 +37,7 @@ class AnnotationProvider with ChangeNotifier {
 
     try {
       var response = await http.get(Uri.parse(finalUrl));
-      // print(response.body);
+      print(response.body);
       // print(response.statusCode);
       if (response.statusCode == 404) {
         // no annotations found
@@ -74,17 +74,25 @@ class AnnotationProvider with ChangeNotifier {
   }
 
   Future<void> addAnnotation(Annotation annotation) async {
+    print("debugging myself");
+    print(annotation.annotationContent);
+    print(annotation.sourceLocation);
+    print(annotation.annotationAuthor);
+    print(annotation.startOffset);
+    print(annotation.endOffset);
     Uri url = Uri.parse("${Constants.annotationUrl}/annotations/create_annotation/");
     var annotationJson = {
       "@context": "http://www.w3.org/ns/anno.jsonld",
       "type": "Annotation",
-      "body": {
+      "body": jsonEncode({
+        // Convert the body object to a JSON string
         "type": "TextualBody",
         "format": "text/html",
         "language": "en",
         "value": annotation.annotationContent,
-      },
-      "target": {
+      }),
+      "target": jsonEncode({
+        // Convert the target object to a JSON string
         "id": annotation.sourceLocation,
         "type": "text",
         "selector": {
@@ -92,13 +100,14 @@ class AnnotationProvider with ChangeNotifier {
           "start": annotation.startOffset,
           "end": annotation.endOffset,
         }
-      },
-      "creator": {
+      }),
+      "creator": jsonEncode({
+        // Convert the creator object to a JSON string
         "id": annotation.annotationAuthor,
         "type": "Person",
-      }
+      })
     };
-
+    print('Sending JSON: ${jsonEncode(annotationJson)}');
     try {
       var response = await http.post(
         url,
@@ -108,6 +117,8 @@ class AnnotationProvider with ChangeNotifier {
         },
         body: jsonEncode(annotationJson),
       );
+      print('Response Status: ${response.statusCode}');
+      print('Response Body: ${response.body}');
       if (response.statusCode == 200) {
         annotation.annotationID = _annotations.length + 1;
         _annotations.add(annotation);

--- a/project/FrontEnd/collaborative_science_platform/lib/providers/annotation_provider.dart
+++ b/project/FrontEnd/collaborative_science_platform/lib/providers/annotation_provider.dart
@@ -13,21 +13,23 @@ class AnnotationProvider with ChangeNotifier {
 
   Future<void> getAnnotations(
       String annotationSourceLocation, List<String> annotationAuthors) async {
-    Uri url = Uri.parse("${Constants.annotationUrl}/annotations/get_annotation");
-    Map<String, String> queryParams = {
-      'source': annotationSourceLocation,
-    };
+    String baseUrl = "${Constants.annotationUrl}/annotations/get_annotation";
 
     // API can match multiple authors
     // WARNING: not sure exactly how to give it as a list
-    if (annotationAuthors.isNotEmpty) {
-      queryParams['creator'] = annotationAuthors.join(',');
+    // Therefore, constructing query parameters manually
+    List<String> queryParams = ['source=$annotationSourceLocation'];
+
+    // Append each author as a separate 'creator' parameter as in Postman
+    for (String author in annotationAuthors) {
+      queryParams.add('creator=${Uri.encodeQueryComponent(author)}');
     }
 
-    url = url.replace(queryParameters: queryParams);
+    // Join all query parameters with '&' and append to the base URL
+    String finalUrl = '$baseUrl?${queryParams.join('&')}';
 
     try {
-      var response = await http.get(url);
+      var response = await http.get(Uri.parse(finalUrl));
       if (response.statusCode == 200) {
         List<dynamic> annotationsJson = jsonDecode(response.body);
 

--- a/project/FrontEnd/collaborative_science_platform/lib/providers/annotation_provider.dart
+++ b/project/FrontEnd/collaborative_science_platform/lib/providers/annotation_provider.dart
@@ -1,5 +1,8 @@
 import 'package:collaborative_science_platform/models/annotation.dart';
+import 'package:collaborative_science_platform/utils/constants.dart';
 import 'package:flutter/material.dart';
+import 'dart:convert';
+import 'package:http/http.dart' as http;
 
 enum AnnotationType { theorem, proof }
 
@@ -8,41 +11,102 @@ class AnnotationProvider with ChangeNotifier {
 
   List<Annotation> get annotations => _annotations;
 
-  Future<void> getAnnotations(AnnotationType annotationType) async {
-    _annotations.clear();
-    if (AnnotationType.theorem == annotationType) {
-      _annotations.add(
-        Annotation(
-          annotationID: 1,
-          annotationContent: "This is an integral.",
-          annotationAuthor: "Author",
-          startOffset: 0,
-          endOffset: 36,
-        ),
-      );
-    } else if (AnnotationType.proof == annotationType) {
-      _annotations.add(
-        Annotation(
-          annotationID: 1,
-          annotationContent: "You need to be carefull here.",
-          annotationAuthor: "Author",
-          startOffset: 152,
-          endOffset: 303,
-        ),
-      );
+  Future<void> getAnnotations(
+      String annotationSourceLocation, List<String> annotationAuthors) async {
+    Uri url = Uri.parse("${Constants.annotationUrl}/annotations/get_annotation");
+    Map<String, String> queryParams = {
+      'source': annotationSourceLocation,
+    };
+
+    // API can match multiple authors
+    // WARNING: not sure exactly how to give it as a list
+    if (annotationAuthors.isNotEmpty) {
+      queryParams['creator'] = annotationAuthors.join(',');
+    }
+
+    url = url.replace(queryParameters: queryParams);
+
+    try {
+      var response = await http.get(url);
+      if (response.statusCode == 200) {
+        List<dynamic> annotationsJson = jsonDecode(response.body);
+
+        _annotations.clear();
+
+        // Parse each JSON object into an Annotation and add to _annotations
+        for (var annotationJson in annotationsJson) {
+          _annotations.add(Annotation(
+            annotationID: int.tryParse(annotationJson['id'].pathSegments.last) ??
+                -1, // Adjust according to your JSON structure
+            startOffset: annotationJson['target']['selector']['start'],
+            endOffset: annotationJson['target']['selector']['end'],
+            annotationContent: annotationJson['body']['value'],
+            annotationAuthor: annotationJson['creator']['id'],
+            sourceLocation: annotationJson['target']['id'],
+          ));
+        }
+        notifyListeners();
+      } else {
+        throw Exception("Something has happened");
+      }
+    } catch (e) {
+      rethrow;
     }
   }
 
   Future<void> addAnnotation(Annotation annotation) async {
-    annotation.annotationID = _annotations.length + 1;
-    _annotations.add(annotation);
-    notifyListeners();
+    Uri url = Uri.parse("${Constants.annotationUrl}/annotations/create_annotation/");
+    var annotationJson = {
+      "@context": "http://www.w3.org/ns/anno.jsonld",
+      "type": "Annotation",
+      "body": {
+        "type": "TextualBody",
+        "format": "text/html",
+        "language": "en",
+        "value": annotation.annotationContent,
+      },
+      "target": {
+        "id": annotation.sourceLocation,
+        "type": "text",
+        "selector": {
+          "type": "TextPositionSelector",
+          "start": annotation.startOffset,
+          "end": annotation.endOffset,
+        }
+      },
+      "creator": {
+        "id": annotation.annotationAuthor,
+        "type": "Person",
+      }
+    };
+
+    try {
+      var response = await http.post(
+        url,
+        headers: {
+          'Accept': 'application/json',
+          'Content-Type': 'application/json',
+        },
+        body: jsonEncode(annotationJson),
+      );
+      if (response.statusCode == 200) {
+        annotation.annotationID = _annotations.length + 1;
+        _annotations.add(annotation);
+        notifyListeners();
+      } else {
+        throw Exception("Something has happened");
+      }
+    } catch (e) {
+      rethrow;
+    }
   }
 
+/*
   Future<void> updateAnnotation(Annotation annotation, String text) async {
     final index =
         _annotations.indexWhere((element) => element.annotationID == annotation.annotationID);
     _annotations[index].annotationContent = text;
     notifyListeners();
   }
+*/
 }

--- a/project/FrontEnd/collaborative_science_platform/lib/screens/node_details_page/widgets/node_details.dart
+++ b/project/FrontEnd/collaborative_science_platform/lib/screens/node_details_page/widgets/node_details.dart
@@ -1,7 +1,6 @@
 import 'package:collaborative_science_platform/helpers/node_helper.dart';
 import 'package:collaborative_science_platform/models/node_details_page/node_detailed.dart';
 import 'package:collaborative_science_platform/providers/auth.dart';
-import 'package:collaborative_science_platform/providers/annotation_provider.dart';
 import 'package:collaborative_science_platform/screens/graph_page/graph_page.dart';
 import 'package:collaborative_science_platform/screens/node_details_page/widgets/contributors_list_view.dart';
 import 'package:collaborative_science_platform/screens/node_details_page/widgets/node_details_menu.dart';
@@ -10,6 +9,7 @@ import 'package:collaborative_science_platform/screens/node_details_page/widgets
 import 'package:collaborative_science_platform/screens/node_details_page/widgets/questions_list_view.dart';
 import 'package:collaborative_science_platform/screens/node_details_page/widgets/references_list_view.dart';
 import 'package:collaborative_science_platform/services/share_page.dart';
+import 'package:collaborative_science_platform/utils/constants.dart';
 import 'package:collaborative_science_platform/utils/text_styles.dart';
 import 'package:collaborative_science_platform/widgets/annotation_text.dart';
 import 'package:collaborative_science_platform/widgets/app_button.dart';
@@ -239,7 +239,10 @@ class _NodeDetailsState extends State<NodeDetails> {
                             child: showAnnotations
                                 ? AnnotationText(
                                     NodeHelper.getNodeContentLatex(widget.node, "long"),
-                                    annotationType: AnnotationType.theorem,
+                                    "${Constants.appUrl}/node/${widget.node.nodeId}#theorem",
+                                    widget.node.contributors
+                                        .map((user) => "${Constants.appUrl}/profile/${user.email}")
+                                        .toList(),
                                   )
                                 : TeXView(
                                     renderingEngine: const TeXViewRenderingEngine.katex(),
@@ -259,7 +262,10 @@ class _NodeDetailsState extends State<NodeDetails> {
               //proofs
               Padding(
                 padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 10),
-                child: ProofListView(proof: widget.node.proof),
+                child: ProofListView(
+                    proof: widget.node.proof,
+                    contributors: widget.node.contributors,
+                    nodeID: widget.node.nodeId),
               ),
             if (currentIndex == 2)
               Padding(

--- a/project/FrontEnd/collaborative_science_platform/lib/screens/node_details_page/widgets/proof_list_view.dart
+++ b/project/FrontEnd/collaborative_science_platform/lib/screens/node_details_page/widgets/proof_list_view.dart
@@ -1,7 +1,9 @@
 import 'package:collaborative_science_platform/models/node_details_page/proof.dart';
+import 'package:collaborative_science_platform/models/user.dart';
 import 'package:collaborative_science_platform/providers/annotation_provider.dart';
 import 'package:collaborative_science_platform/utils/responsive/responsive.dart';
 import 'package:collaborative_science_platform/utils/text_styles.dart';
+import 'package:collaborative_science_platform/utils/constants.dart';
 import 'package:collaborative_science_platform/widgets/annotation_text.dart';
 import 'package:collaborative_science_platform/widgets/app_button.dart';
 import 'package:collaborative_science_platform/widgets/card_container.dart';
@@ -11,7 +13,10 @@ import 'dart:convert';
 
 class ProofListView extends StatefulWidget {
   final List<Proof> proof;
-  const ProofListView({super.key, required this.proof});
+  final List<User> contributors;
+  final int nodeID;
+  const ProofListView(
+      {super.key, required this.proof, required this.contributors, required this.nodeID});
 
   @override
   State<ProofListView> createState() => _ProofListViewState();
@@ -66,7 +71,10 @@ class _ProofListViewState extends State<ProofListView> {
                     showAnnotations
                         ? AnnotationText(
                             utf8.decode(widget.proof[index].proofContent.codeUnits),
-                            annotationType: AnnotationType.proof,
+                            "${Constants.appUrl}/node/${widget.nodeID}#proof#${index}",
+                            widget.contributors
+                                .map((user) => "${Constants.appUrl}/profile/${user.email}")
+                                .toList(),
                           )
                         : TeXView(
                             renderingEngine: const TeXViewRenderingEngine.katex(),

--- a/project/FrontEnd/collaborative_science_platform/lib/utils/constants.dart
+++ b/project/FrontEnd/collaborative_science_platform/lib/utils/constants.dart
@@ -2,4 +2,6 @@ class Constants {
   static const String appName = "Collaborative Science Platform";
   static const String appUrl = "http://13.51.205.39";
   static const String apiUrl = "http://13.51.55.11:8000/api";
+  static const String annotationUrl = "http://13.51.55.11:8001";
+  static const String annotationServer = "http://13.51.205.39";
 }

--- a/project/FrontEnd/collaborative_science_platform/lib/utils/constants.dart
+++ b/project/FrontEnd/collaborative_science_platform/lib/utils/constants.dart
@@ -3,5 +3,4 @@ class Constants {
   static const String appUrl = "http://13.51.205.39";
   static const String apiUrl = "http://13.51.55.11:8000/api";
   static const String annotationUrl = "http://13.51.55.11:8001";
-  static const String annotationServer = "http://13.51.205.39";
 }

--- a/project/FrontEnd/collaborative_science_platform/lib/widgets/annotation_text.dart
+++ b/project/FrontEnd/collaborative_science_platform/lib/widgets/annotation_text.dart
@@ -2,6 +2,7 @@ import 'dart:ui';
 
 import 'package:collaborative_science_platform/models/annotation.dart';
 import 'package:collaborative_science_platform/providers/annotation_provider.dart';
+import 'package:collaborative_science_platform/providers/auth.dart';
 import 'package:collaborative_science_platform/utils/colors.dart';
 import 'package:collaborative_science_platform/utils/responsive/responsive.dart';
 import 'package:flutter/material.dart';
@@ -136,12 +137,11 @@ class _AnnotationTextState extends State<AnnotationText> {
                         anchor: editableTextState.contextMenuAnchors.primaryAnchor,
                         selectedText: widget.text.substring(element.startOffset, element.endOffset),
                         annotation: element,
+                        sourceLocation: widget.annotationSourceLocation,
                         children: AdaptiveTextSelectionToolbar.getAdaptiveButtons(
                           context,
                           editableTextState.contextMenuButtonItems,
                         ).toList(),
-                        sourceLocation: widget.annotationSourceLocation,
-                        author: "http://13.51.205.39/profile/cemsay@gmail.com", //TODO
                       );
                     }
                   }
@@ -150,12 +150,11 @@ class _AnnotationTextState extends State<AnnotationText> {
                     selectedText: selectedText.trim(),
                     startOffset: selectedIndices.baseOffset,
                     endOffset: selectedIndices.extentOffset,
+                    sourceLocation: widget.annotationSourceLocation,
                     children: AdaptiveTextSelectionToolbar.getAdaptiveButtons(
                       context,
                       editableTextState.contextMenuButtonItems,
-                    ).toList(),
-                    sourceLocation: widget.annotationSourceLocation,
-                    author: "http://13.51.205.39/profile/cemsay@gmail.com", //TODO
+                    ).toList(), //TODO
                   );
                 },
               );
@@ -171,7 +170,6 @@ class _MyContextMenu extends StatelessWidget {
     required this.children,
     required this.selectedText,
     required this.sourceLocation,
-    required this.author,
     this.annotation,
     this.startOffset,
     this.endOffset,
@@ -181,7 +179,6 @@ class _MyContextMenu extends StatelessWidget {
   final List<Widget> children;
   final String selectedText;
   final String sourceLocation;
-  final String author;
 
   @override
   Widget build(BuildContext context) {
@@ -200,20 +197,23 @@ class _MyContextMenu extends StatelessWidget {
               mainAxisAlignment: MainAxisAlignment.start,
               children: [
                 //...children,
-                AddAnnotationButton(
-                    text: selectedText,
-                    startOffset: startOffset,
-                    endOffset: endOffset,
-                    annotation: annotation,
-                    sourceLocation: sourceLocation,
-                    author: author),
-                const SizedBox(height: 2),
-                annotation != null
-                    ? ShowAnnotationButton(
+                if (Provider.of<Auth>(context).isSignedIn)
+                  AddAnnotationButton(
+                      text: selectedText,
+                      startOffset: startOffset,
+                      endOffset: endOffset,
+                      annotation: annotation,
+                      sourceLocation: sourceLocation),
+                if (annotation != null)
+                  Column(
+                    children: [
+                      const SizedBox(height: 2),
+                      ShowAnnotationButton(
                         text: selectedText,
                         annotation: annotation!,
-                      )
-                    : const SizedBox(),
+                      ),
+                    ],
+                  )
               ],
             ),
           ),
@@ -410,7 +410,6 @@ class AddAnnotationButton extends StatefulWidget {
   final int? endOffset;
   final Annotation? annotation;
   final String sourceLocation;
-  final String author;
   const AddAnnotationButton({
     super.key,
     required this.text,
@@ -418,7 +417,6 @@ class AddAnnotationButton extends StatefulWidget {
     this.startOffset,
     this.endOffset,
     required this.sourceLocation,
-    required this.author,
   }) : assert(annotation == null ||
             (startOffset == null && endOffset == null) ||
             (startOffset != null && endOffset != null));
@@ -467,7 +465,8 @@ class _AddAnnotationButtonState extends State<AddAnnotationButton> {
           annotationContent: _textEditingController.text,
           startOffset: widget.startOffset!,
           endOffset: widget.endOffset!,
-          annotationAuthor: widget.author,
+          annotationAuthor:
+              "http://13.51.205.39/profile/${Provider.of<Auth>(context, listen: false).user!.id}",
           sourceLocation: widget.sourceLocation,
         );
         await provider.addAnnotation(annotation);

--- a/project/FrontEnd/collaborative_science_platform/lib/widgets/annotation_text.dart
+++ b/project/FrontEnd/collaborative_science_platform/lib/widgets/annotation_text.dart
@@ -140,6 +140,8 @@ class _AnnotationTextState extends State<AnnotationText> {
                           context,
                           editableTextState.contextMenuButtonItems,
                         ).toList(),
+                        sourceLocation: widget.annotationSourceLocation,
+                        author: "http://13.51.205.39/profile/cemsay@gmail.com", //TODO
                       );
                     }
                   }
@@ -152,6 +154,8 @@ class _AnnotationTextState extends State<AnnotationText> {
                       context,
                       editableTextState.contextMenuButtonItems,
                     ).toList(),
+                    sourceLocation: widget.annotationSourceLocation,
+                    author: "http://13.51.205.39/profile/cemsay@gmail.com", //TODO
                   );
                 },
               );
@@ -166,6 +170,8 @@ class _MyContextMenu extends StatelessWidget {
     required this.anchor,
     required this.children,
     required this.selectedText,
+    required this.sourceLocation,
+    required this.author,
     this.annotation,
     this.startOffset,
     this.endOffset,
@@ -174,6 +180,8 @@ class _MyContextMenu extends StatelessWidget {
   final Offset anchor;
   final List<Widget> children;
   final String selectedText;
+  final String sourceLocation;
+  final String author;
 
   @override
   Widget build(BuildContext context) {
@@ -196,7 +204,9 @@ class _MyContextMenu extends StatelessWidget {
                     text: selectedText,
                     startOffset: startOffset,
                     endOffset: endOffset,
-                    annotation: annotation),
+                    annotation: annotation,
+                    sourceLocation: sourceLocation,
+                    author: author),
                 const SizedBox(height: 2),
                 annotation != null
                     ? ShowAnnotationButton(
@@ -399,9 +409,17 @@ class AddAnnotationButton extends StatefulWidget {
   final int? startOffset;
   final int? endOffset;
   final Annotation? annotation;
-  const AddAnnotationButton(
-      {super.key, required this.text, this.annotation, this.startOffset, this.endOffset})
-      : assert(annotation == null ||
+  final String sourceLocation;
+  final String author;
+  const AddAnnotationButton({
+    super.key,
+    required this.text,
+    this.annotation,
+    this.startOffset,
+    this.endOffset,
+    required this.sourceLocation,
+    required this.author,
+  }) : assert(annotation == null ||
             (startOffset == null && endOffset == null) ||
             (startOffset != null && endOffset != null));
 
@@ -409,7 +427,6 @@ class AddAnnotationButton extends StatefulWidget {
   State<AddAnnotationButton> createState() => _AddAnnotationButtonState();
 }
 
-// NOT IMPLEMENTED FULLY // TODO
 class _AddAnnotationButtonState extends State<AddAnnotationButton> {
   bool isHovering = false;
   bool isPortalOpen = false;
@@ -450,8 +467,8 @@ class _AddAnnotationButtonState extends State<AddAnnotationButton> {
           annotationContent: _textEditingController.text,
           startOffset: widget.startOffset!,
           endOffset: widget.endOffset!,
-          annotationAuthor: "TODO", // TODO
-          sourceLocation: "TODO", // TODO
+          annotationAuthor: widget.author,
+          sourceLocation: widget.sourceLocation,
         );
         await provider.addAnnotation(annotation);
       }

--- a/project/FrontEnd/collaborative_science_platform/lib/widgets/annotation_text.dart
+++ b/project/FrontEnd/collaborative_science_platform/lib/widgets/annotation_text.dart
@@ -11,18 +11,20 @@ import 'package:provider/provider.dart';
 
 class AnnotationText extends StatefulWidget {
   final String text;
-  final AnnotationType annotationType;
+  final String annotationSourceLocation;
+  final List<String> annotationAuthors;
   final TextStyle? style;
   final TextAlign? textAlign;
   final int? maxLines;
 
   const AnnotationText(
-    this.text, {
+    this.text,
+    this.annotationSourceLocation,
+    this.annotationAuthors, {
     super.key,
     this.style,
     this.textAlign,
     this.maxLines,
-    this.annotationType = AnnotationType.theorem,
   });
 
   @override
@@ -53,7 +55,8 @@ class _AnnotationTextState extends State<AnnotationText> {
         isLoading = true;
       });
       final annotationProvider = Provider.of<AnnotationProvider>(context);
-      await annotationProvider.getAnnotations(widget.annotationType);
+      await annotationProvider.getAnnotations(
+          widget.annotationSourceLocation, widget.annotationAuthors);
       annotations = annotationProvider.annotations;
       for (var element in annotations) {
         annotationIndices.add(element.startOffset);
@@ -406,6 +409,7 @@ class AddAnnotationButton extends StatefulWidget {
   State<AddAnnotationButton> createState() => _AddAnnotationButtonState();
 }
 
+// NOT IMPLEMENTED FULLY // TODO
 class _AddAnnotationButtonState extends State<AddAnnotationButton> {
   bool isHovering = false;
   bool isPortalOpen = false;
@@ -432,14 +436,22 @@ class _AddAnnotationButtonState extends State<AddAnnotationButton> {
       });
     }
     try {
+      // no update or remove mechanism implemented yet in backend
+      // DELETE this later if it won't be implemented
       if (change) {
-        await provider.updateAnnotation(widget.annotation!, _textEditingController.text);
+        scaffoldMessenger.showSnackBar(
+          const SnackBar(
+            content: Text("Something went wrong!"),
+          ),
+        );
+        //  await provider.updateAnnotation(widget.annotation!, _textEditingController.text);
       } else {
         Annotation annotation = Annotation(
           annotationContent: _textEditingController.text,
           startOffset: widget.startOffset!,
           endOffset: widget.endOffset!,
-          annotationAuthor: "test",
+          annotationAuthor: "TODO", // TODO
+          sourceLocation: "TODO", // TODO
         );
         await provider.addAnnotation(annotation);
       }


### PR DESCRIPTION
Annotation Provider for GET and POST APIs.

### Implemented
- [x] Annotation Provider for GET Annotations
- [x] Annotation Provider for POST Annotations
- [x] Integrity with frontend's annotation get mechanism
- [x] Apply this mechanism to Node's theorem and proofs 
- [x]  Integrity with frontend's annotation add mechanism

### TODO & Problems
- [x] Currently, while adding annotation, author of it hardcoded as cemsay@gmail. This annotation mechanism should not be visible to not users, (should be visible to only contributors of node?)
- [x] ShowAnnotations sometimes shows one annotation even in AnnotationText we get all annotations of that card.(I believe it's problem when multiple annotation is done to same location so wouldn't be so much problem after implementing author restriction.)
- [x] Currently only annotations of contributors showed, user own annotations could be added. [OPTIONAL]

### Additional
- [x]  Change annotation body feature is added with last commit

### Testing
- Added an annotation to a proof or theorem which hasn't had any annotation previously, then saw the added annotation correctly. So this basic mechanism works as expected, but multiple annotation support in one widget and restriction to who can add annotations is remains as TODO.
- Tested on node/2#proof#1 : this one supported multiple annotations, I believe it's an issue when annotations are close to each other or maybe when they conflict. 